### PR TITLE
feat: Remove the need of explicitly passing a DataModel to read from Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,17 +580,6 @@ class FinalBar(WithLocal, WithKafka, DynamicDataIO):
 
     schema = SCHEMA_FROM_FILE
 
-
-class BarDataModel(Base):
-    """Sql_alchemy model for Bar table."""
-
-    __tablename__ = "bar"
-
-    column_a = Column(String(64), primary_key=True)
-    column_b = Column(String(64))
-    column_c = Column(Float)
-    column_d = Column(Float)
-
 ```
 
 Instances of the `DynamicDataIO` class **must** define a class `schema`. The schema has the form of a dictionary, associating columns (keys) with `dtypes` (values).
@@ -734,45 +723,15 @@ which will load the `foo.csv` file as a dataframe.
 
 ##### Step 4.3: Loading from `Postgres`
 
-In contrast to `S3` resources, `postgres` resources need additional options to be
-defined for their loading.
+Likewise to `S3` resources, `postgres` resources need the same number of options to be defined for their loading.
 
-Specifically, you need to define a data model, defining the table, the columns and
-their respective SQL types. This is necessary as a different reader is utilised in
-the case of postgres (this need will be addressed in future releases).
-
-The data model definition is also defined in `io.py` and looks like:
-
-```python
-"""
-A module for defining sql_alchemy models.
-"""
-__all__ = ["BarDataModel"]
-
-from sqlalchemy import Column, Float, String
-from sqlalchemy.ext.declarative import declarative_base
-
-Base = declarative_base()
-
-
-class BarDataModel(Base):
-    """
-    Sql_alchemy model for Bar table
-    """
-
-    __tablename__ = "bar"
-
-    column_a = Column(String(64), primary_key=True)
-    column_b = Column(String(64))
-    column_c = Column(Float)
-    column_d = Column(Float)
-
-```
+**Implicitly, dynamicio is able to infer data model from the schema yml files of the source key provided rather than requiring that the schema is explicitly defined.**
+This data model defines the table, the columns andtheir respective SQL types.
 
 To, then, load from `postgres` you simply do:
 
 ```python
-    bar_df = Bar(source_config=input_config.get(source_key="BAR"), apply_schema_validations=True, log_schema_metrics=True, model=BarDataModel).read()
+    bar_df = Bar(source_config=input_config.get(source_key="BAR"), apply_schema_validations=True, log_schema_metrics=True).read()
 ```
 
 which will load the cargo the movements table as a dataframe.
@@ -909,7 +868,7 @@ def main() -> None:
     # LOAD DATA
     logger.info("Loading data from live sources...")
 
-    bar_df = Bar(source_config=input_config.get(source_key="BAR"), apply_schema_validations=True, log_schema_metrics=True, model=BarDataModel).read()
+    bar_df = Bar(source_config=input_config.get(source_key="BAR"), apply_schema_validations=True, log_schema_metrics=True).read()
     foo_df = Foo(source_config=input_config.get(source_key="FOO"), apply_schema_validations=True, log_schema_metrics=True).read()
 
     logger.info("Data successfully loaded from live sources...")

--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ which will load the `foo.csv` file as a dataframe.
 Likewise to `S3` resources, `postgres` resources need the same number of options to be defined for their loading.
 
 **Implicitly, dynamicio is able to infer data model from the schema yml files of the source key provided rather than requiring that the schema is explicitly defined.**
-This data model defines the table, the columns andtheir respective SQL types.
+This data model defines the table, the columns and their respective SQL types.
 
 To, then, load from `postgres` you simply do:
 

--- a/README.md
+++ b/README.md
@@ -985,3 +985,4 @@ class TestPipeline:
 Hope this was helpful. 
 
 Please do reach out with comments and your views about how the library or the docs can be improved, and by all means, come along and contribute to our project!
+

--- a/demo/src/io.py
+++ b/demo/src/io.py
@@ -1,6 +1,6 @@
 """Responsible for configuring io operations for input data."""
 # pylint: disable=too-few-public-methods
-__all__ = ["Foo", "Bar", "StagedFoo", "StagedBar", "BarDataModel", "FinalFoo", "FinalBar"]
+__all__ = ["Foo", "Bar", "StagedFoo", "StagedBar", "FinalFoo", "FinalBar"]
 
 from sqlalchemy import Column, Float, String
 from sqlalchemy.ext.declarative import declarative_base
@@ -55,14 +55,3 @@ class FinalBar(WithLocal, WithKafka, DynamicDataIO):
     """UnifiedIO subclass for cargo movements volumes data."""
 
     schema = SCHEMA_FROM_FILE
-
-
-class BarDataModel(Base):
-    """Sql_alchemy model for Bar table."""
-
-    __tablename__ = "bar"
-
-    column_a = Column(String(64), primary_key=True)
-    column_b = Column(String(64))
-    column_c = Column(Float)
-    column_d = Column(Float)

--- a/demo/src/runners/staging.py
+++ b/demo/src/runners/staging.py
@@ -2,7 +2,7 @@
 import logging
 
 from demo.src import constants, input_config, raw_config
-from demo.src.io import Bar, BarDataModel, Foo, StagedBar, StagedFoo
+from demo.src.io import Bar, Foo, StagedBar, StagedFoo
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +16,7 @@ def main() -> None:
     # LOAD DATA
     logger.info("Loading data from live sources...")
 
-    bar_df = Bar(source_config=input_config.get(source_key="BAR"), apply_schema_validations=True, log_schema_metrics=True, model=BarDataModel).read()
+    bar_df = Bar(source_config=input_config.get(source_key="BAR"), apply_schema_validations=True, log_schema_metrics=True).read()
     foo_df = Foo(source_config=input_config.get(source_key="FOO"), apply_schema_validations=True, log_schema_metrics=True).read()
 
     logger.info("Data successfully loaded from live sources...")

--- a/docs/config.html
+++ b/docs/config.html
@@ -275,6 +275,7 @@ class IOConfig:
         source_config = self.config[source_key][self.env_identifier]
         if self.config[source_key].get(&#34;schema&#34;):
             schema_definition = self._get_schema_definition(source_key)
+            source_config[&#34;name&#34;] = schema_definition[&#34;name&#34;]
             source_config[&#34;schema&#34;] = self._get_schema(schema_definition)
             source_config[&#34;validations&#34;] = self._get_validations(schema_definition)
             source_config[&#34;metrics&#34;] = self._get_metrics(schema_definition)
@@ -470,6 +471,7 @@ may reference.</dd>
         source_config = self.config[source_key][self.env_identifier]
         if self.config[source_key].get(&#34;schema&#34;):
             schema_definition = self._get_schema_definition(source_key)
+            source_config[&#34;name&#34;] = schema_definition[&#34;name&#34;]
             source_config[&#34;schema&#34;] = self._get_schema(schema_definition)
             source_config[&#34;validations&#34;] = self._get_validations(schema_definition)
             source_config[&#34;metrics&#34;] = self._get_metrics(schema_definition)
@@ -650,6 +652,7 @@ voyage_data_cloud_mapping = input_config.get(source_key="VOYAGE_DATA")
     source_config = self.config[source_key][self.env_identifier]
     if self.config[source_key].get(&#34;schema&#34;):
         schema_definition = self._get_schema_definition(source_key)
+        source_config[&#34;name&#34;] = schema_definition[&#34;name&#34;]
         source_config[&#34;schema&#34;] = self._get_schema(schema_definition)
         source_config[&#34;validations&#34;] = self._get_validations(schema_definition)
         source_config[&#34;metrics&#34;] = self._get_metrics(schema_definition)

--- a/docs/core.html
+++ b/docs/core.html
@@ -292,8 +292,11 @@ class DynamicDataIO:
             bool - `True` if `df` has the given dtypes, `False` otherwise
         &#34;&#34;&#34;
         dtypes = df.dtypes
+        print(&#34;dtypes: &#34;, dtypes)
+        print(&#34;\ndf:&#34;, df)
 
         for column_name, expected_dtype in self.schema.items():
+            print(f&#34;\n{column_name} ---- {expected_dtype}&#34;)
             found_dtype = dtypes[column_name].name
             if found_dtype != expected_dtype:
                 if self.show_casting_warnings:
@@ -622,8 +625,11 @@ class DynamicDataIO:
             bool - `True` if `df` has the given dtypes, `False` otherwise
         &#34;&#34;&#34;
         dtypes = df.dtypes
+        print(&#34;dtypes: &#34;, dtypes)
+        print(&#34;\ndf:&#34;, df)
 
         for column_name, expected_dtype in self.schema.items():
+            print(f&#34;\n{column_name} ---- {expected_dtype}&#34;)
             found_dtype = dtypes[column_name].name
             if found_dtype != expected_dtype:
                 if self.show_casting_warnings:

--- a/docs/mixins.html
+++ b/docs/mixins.html
@@ -49,7 +49,7 @@ import tempfile
 from contextlib import contextmanager
 from functools import wraps
 from types import FunctionType
-from typing import Any, Callable, Collection, Generator, Iterable, Mapping, MutableMapping, Optional, Union
+from typing import Any, Callable, Collection, Dict, Generator, Iterable, Mapping, MutableMapping, Optional, Union
 
 import boto3  # type: ignore
 import pandas as pd  # type: ignore
@@ -61,6 +61,7 @@ from magic_logger import logger
 from pyarrow.parquet import read_table, write_table  # type: ignore # pylint: disable=no-name-in-module
 from sqlalchemy import Boolean, Column, Float, Integer, String, create_engine  # type: ignore
 from sqlalchemy.ext.declarative import declarative_base  # type: ignore
+from sqlalchemy.orm.decl_api import DeclarativeMeta  # type: ignore
 from sqlalchemy.orm import Query  # type: ignore
 from sqlalchemy.orm.session import Session as SqlAlchemySession  # type: ignore
 from sqlalchemy.orm.session import sessionmaker  # type: ignore
@@ -709,9 +710,6 @@ class WithPostgres:
 
         query = None
 
-        if self.options.get(&#34;model&#34;):
-            raise ValueError(&#34;`model` must not be provided&#34;)
-
         if &#34;schema&#34; not in self.sources_config:
             schema_dict = self.schema
         else:
@@ -728,18 +726,8 @@ class WithPostgres:
             return self._read_database(session, query, **self.options)
 
     @staticmethod
-    def _generate_model_from_schema(schema_dict, schema_name):
-        &#34;&#34;&#34;Generates a model from a schema loaded from yaml file.
-
-        Args:
-            schema_dict&lt;dict&gt;: A dictionary from source_config variable containing
-                                columns and their types
-            schema_name&lt;string&gt;: Name of the schema from schema yaml file.
-
-        Returns:
-            &lt;class &#39;sqlalchemy.orm.decl_api.DeclarativeMeta&#39;&gt;
-        &#34;&#34;&#34;
-        json_cls_schema = {&#34;tablename&#34;: schema_name, &#34;columns&#34;: []}
+    def _generate_model_from_schema(schema_dict: Mapping, schema_name: str) -&gt; DeclarativeMeta:
+        json_cls_schema: Dict[str, Any] = {&#34;tablename&#34;: schema_name, &#34;columns&#34;: []}
 
         for col, dtype in schema_dict.items():
             new_col = {&#34;name&#34;: col}
@@ -748,25 +736,24 @@ class WithPostgres:
                 new_col.update({&#34;name&#34;: col, &#34;type&#34;: _type_lookup[dtype]})
                 json_cls_schema[&#34;columns&#34;].append(new_col)
 
-        class_name = &#34;&#34;.join(x.capitalize() or &#34;_&#34; for x in schema_name.split(&#34;_&#34;)) + &#34;Model&#34;
+        class_name = &#34;&#34;.join(word.capitalize() or &#34;_&#34; for word in schema_name.split(&#34;_&#34;)) + &#34;Model&#34;
 
         class_dict = {&#34;clsname&#34;: class_name, &#34;__tablename__&#34;: schema_name, &#34;__table_args__&#34;: {&#34;extend_existing&#34;: True}}
         class_dict.update({column[&#34;name&#34;]: Column(column[&#34;type&#34;], primary_key=True) if idx == 0 else Column(column[&#34;type&#34;]) for idx, column in enumerate(json_cls_schema[&#34;columns&#34;])})
-        generated_model = type(class_dict[&#34;clsname&#34;], (Base,), class_dict)
+
+        generated_model = type(class_name, (Base,), class_dict)
         return generated_model
 
     @staticmethod
     def _get_table_columns(model):
+        tables_colums = []
         if model:
-            tables_colums = []
             for col in list(model.__table__.columns):
                 tables_colums.append(getattr(model, col.name))
-            return tables_colums
-            # return list(model.__table__.columns)
-        raise ValueError(&#34;A model must be provided&#34;)
+        return tables_colums
 
     @staticmethod
-    @allow_options([*args_of(pd.read_sql), *[&#34;model&#34;]])
+    @allow_options(pd.read_sql)
     def _read_database(session: SqlAlchemySession, query: Union[str, Query], **options: Any) -&gt; pd.DataFrame:
         &#34;&#34;&#34;Run `query` against active `session` and returns the result as a `DataFrame`.
 
@@ -803,9 +790,6 @@ class WithPostgres:
         db_name = postgres_config[&#34;db_name&#34;]
 
         connection_string = f&#34;postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}&#34;
-
-        if self.options.get(&#34;model&#34;):
-            raise ValueError(&#34;`model` must not be provided&#34;)
 
         schema_dict = self.sources_config[&#34;schema&#34;]
         schema_name = self.sources_config[&#34;name&#34;]
@@ -1702,9 +1686,6 @@ Kafka topic.</p>
 
         query = None
 
-        if self.options.get(&#34;model&#34;):
-            raise ValueError(&#34;`model` must not be provided&#34;)
-
         if &#34;schema&#34; not in self.sources_config:
             schema_dict = self.schema
         else:
@@ -1721,18 +1702,8 @@ Kafka topic.</p>
             return self._read_database(session, query, **self.options)
 
     @staticmethod
-    def _generate_model_from_schema(schema_dict, schema_name):
-        &#34;&#34;&#34;Generates a model from a schema loaded from yaml file.
-
-        Args:
-            schema_dict&lt;dict&gt;: A dictionary from source_config variable containing
-                                columns and their types
-            schema_name&lt;string&gt;: Name of the schema from schema yaml file.
-
-        Returns:
-            &lt;class &#39;sqlalchemy.orm.decl_api.DeclarativeMeta&#39;&gt;
-        &#34;&#34;&#34;
-        json_cls_schema = {&#34;tablename&#34;: schema_name, &#34;columns&#34;: []}
+    def _generate_model_from_schema(schema_dict: Mapping, schema_name: str) -&gt; DeclarativeMeta:
+        json_cls_schema: Dict[str, Any] = {&#34;tablename&#34;: schema_name, &#34;columns&#34;: []}
 
         for col, dtype in schema_dict.items():
             new_col = {&#34;name&#34;: col}
@@ -1741,25 +1712,24 @@ Kafka topic.</p>
                 new_col.update({&#34;name&#34;: col, &#34;type&#34;: _type_lookup[dtype]})
                 json_cls_schema[&#34;columns&#34;].append(new_col)
 
-        class_name = &#34;&#34;.join(x.capitalize() or &#34;_&#34; for x in schema_name.split(&#34;_&#34;)) + &#34;Model&#34;
+        class_name = &#34;&#34;.join(word.capitalize() or &#34;_&#34; for word in schema_name.split(&#34;_&#34;)) + &#34;Model&#34;
 
         class_dict = {&#34;clsname&#34;: class_name, &#34;__tablename__&#34;: schema_name, &#34;__table_args__&#34;: {&#34;extend_existing&#34;: True}}
         class_dict.update({column[&#34;name&#34;]: Column(column[&#34;type&#34;], primary_key=True) if idx == 0 else Column(column[&#34;type&#34;]) for idx, column in enumerate(json_cls_schema[&#34;columns&#34;])})
-        generated_model = type(class_dict[&#34;clsname&#34;], (Base,), class_dict)
+
+        generated_model = type(class_name, (Base,), class_dict)
         return generated_model
 
     @staticmethod
     def _get_table_columns(model):
+        tables_colums = []
         if model:
-            tables_colums = []
             for col in list(model.__table__.columns):
                 tables_colums.append(getattr(model, col.name))
-            return tables_colums
-            # return list(model.__table__.columns)
-        raise ValueError(&#34;A model must be provided&#34;)
+        return tables_colums
 
     @staticmethod
-    @allow_options([*args_of(pd.read_sql), *[&#34;model&#34;]])
+    @allow_options(pd.read_sql)
     def _read_database(session: SqlAlchemySession, query: Union[str, Query], **options: Any) -&gt; pd.DataFrame:
         &#34;&#34;&#34;Run `query` against active `session` and returns the result as a `DataFrame`.
 
@@ -1796,9 +1766,6 @@ Kafka topic.</p>
         db_name = postgres_config[&#34;db_name&#34;]
 
         connection_string = f&#34;postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}&#34;
-
-        if self.options.get(&#34;model&#34;):
-            raise ValueError(&#34;`model` must not be provided&#34;)
 
         schema_dict = self.sources_config[&#34;schema&#34;]
         schema_name = self.sources_config[&#34;name&#34;]

--- a/docs/mixins.html
+++ b/docs/mixins.html
@@ -59,12 +59,16 @@ from fastparquet import ParquetFile, write  # type: ignore
 from kafka import KafkaProducer  # type: ignore
 from magic_logger import logger
 from pyarrow.parquet import read_table, write_table  # type: ignore # pylint: disable=no-name-in-module
-from sqlalchemy import create_engine  # type: ignore
+from sqlalchemy import Boolean, Column, Float, Integer, String, create_engine  # type: ignore
+from sqlalchemy.ext.declarative import declarative_base  # type: ignore
 from sqlalchemy.orm import Query  # type: ignore
 from sqlalchemy.orm.session import Session as SqlAlchemySession  # type: ignore
 from sqlalchemy.orm.session import sessionmaker  # type: ignore
 
 Session = sessionmaker(autoflush=True)
+
+Base = declarative_base()
+_type_lookup = {&#34;boolean&#34;: Boolean, &#34;object&#34;: String(64), &#34;int64&#34;: Integer, &#34;float64&#34;: Float, &#34;int&#34;: Integer}
 
 
 @contextmanager
@@ -701,28 +705,63 @@ class WithPostgres:
 
         connection_string = f&#34;postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}&#34;
 
-        model = self.options.get(&#34;model&#34;)
         sql_query = self.options.get(&#34;sql_query&#34;)
 
         query = None
 
-        if model and sql_query:
-            raise ValueError(&#34;Only one of `model` and `sql_query` must be provided&#34;)
-        if model is None and sql_query is None:
-            raise ValueError(&#34;One of `model` and `sql_query` must be provided&#34;)
+        if self.options.get(&#34;model&#34;):
+            raise ValueError(&#34;`model` must not be provided&#34;)
 
-        if model:
-            query = Query(self._get_table_columns(model))
+        if &#34;schema&#34; not in self.sources_config:
+            schema_dict = self.schema
         else:
+            schema_dict = self.sources_config[&#34;schema&#34;]
+        schema_name = self.sources_config[&#34;name&#34;]
+
+        model = self._generate_model_from_schema(schema_dict, schema_name)
+
+        query = Query(self._get_table_columns(model))
+        if sql_query:
             query = sql_query
 
         with session_for(connection_string) as session:
             return self._read_database(session, query, **self.options)
 
     @staticmethod
+    def _generate_model_from_schema(schema_dict, schema_name):
+        &#34;&#34;&#34;Generates a model from a schema loaded from yaml file.
+        Args:
+            schema_dict&lt;dict&gt;: A dictionary from source_config variable containing
+                                columns and their types
+            schema_name&lt;string&gt;: Name of the schema from schema yaml file.
+
+        Returns:
+            &lt;class &#39;sqlalchemy.orm.decl_api.DeclarativeMeta&#39;&gt;
+        &#34;&#34;&#34;
+        json_cls_schema = {&#34;tablename&#34;: schema_name, &#34;columns&#34;: []}
+
+        for col, dtype in schema_dict.items():
+            new_col = {&#34;name&#34;: col}
+
+            if dtype in _type_lookup:
+                new_col.update({&#34;name&#34;: col, &#34;type&#34;: _type_lookup[dtype]})
+                json_cls_schema[&#34;columns&#34;].append(new_col)
+
+        class_name = &#34;&#34;.join(x.capitalize() or &#34;_&#34; for x in schema_name.split(&#34;_&#34;)) + &#34;Model&#34;
+
+        class_dict = {&#34;clsname&#34;: class_name, &#34;__tablename__&#34;: schema_name, &#34;__table_args__&#34;: {&#34;extend_existing&#34;: True}}
+        class_dict.update({column[&#34;name&#34;]: Column(column[&#34;type&#34;], primary_key=True) if idx == 0 else Column(column[&#34;type&#34;]) for idx, column in enumerate(json_cls_schema[&#34;columns&#34;])})
+        generated_model = type(class_dict[&#34;clsname&#34;], (Base,), class_dict)
+        return generated_model
+
+    @staticmethod
     def _get_table_columns(model):
         if model:
-            return list(model.__table__.columns)
+            tables_colums = []
+            for col in list(model.__table__.columns):
+                tables_colums.append(getattr(model, col.name))
+            return tables_colums
+            # return list(model.__table__.columns)
         raise ValueError(&#34;A model must be provided&#34;)
 
     @staticmethod
@@ -745,7 +784,6 @@ class WithPostgres:
             query = query.with_session(session).statement
         return pd.read_sql(sql=query, con=session.get_bind(), **options)
 
-    @allow_options({&#34;model&#34;})
     def _write_to_postgres(self, df: pd.DataFrame):
         &#34;&#34;&#34;Write a dataframe to postgres based on the {file_type} of the config_io configuration.
 
@@ -765,8 +803,15 @@ class WithPostgres:
 
         connection_string = f&#34;postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}&#34;
 
+        if self.options.get(&#34;model&#34;):
+            raise ValueError(&#34;`model` must not be provided&#34;)
+
+        schema_dict = self.sources_config[&#34;schema&#34;]
+        schema_name = self.sources_config[&#34;name&#34;]
+        model = self._generate_model_from_schema(schema_dict, schema_name)
+
         with session_for(connection_string) as session:
-            self._write_to_database(session, self.options[&#34;model&#34;].__tablename__, df)  # type: ignore
+            self._write_to_database(session, model.__tablename__, df)  # type: ignore
 
     @staticmethod
     def _write_to_database(session: SqlAlchemySession, table_name: str, df: pd.DataFrame):
@@ -1652,28 +1697,63 @@ Kafka topic.</p>
 
         connection_string = f&#34;postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}&#34;
 
-        model = self.options.get(&#34;model&#34;)
         sql_query = self.options.get(&#34;sql_query&#34;)
 
         query = None
 
-        if model and sql_query:
-            raise ValueError(&#34;Only one of `model` and `sql_query` must be provided&#34;)
-        if model is None and sql_query is None:
-            raise ValueError(&#34;One of `model` and `sql_query` must be provided&#34;)
+        if self.options.get(&#34;model&#34;):
+            raise ValueError(&#34;`model` must not be provided&#34;)
 
-        if model:
-            query = Query(self._get_table_columns(model))
+        if &#34;schema&#34; not in self.sources_config:
+            schema_dict = self.schema
         else:
+            schema_dict = self.sources_config[&#34;schema&#34;]
+        schema_name = self.sources_config[&#34;name&#34;]
+
+        model = self._generate_model_from_schema(schema_dict, schema_name)
+
+        query = Query(self._get_table_columns(model))
+        if sql_query:
             query = sql_query
 
         with session_for(connection_string) as session:
             return self._read_database(session, query, **self.options)
 
     @staticmethod
+    def _generate_model_from_schema(schema_dict, schema_name):
+        &#34;&#34;&#34;Generates a model from a schema loaded from yaml file.
+        Args:
+            schema_dict&lt;dict&gt;: A dictionary from source_config variable containing
+                                columns and their types
+            schema_name&lt;string&gt;: Name of the schema from schema yaml file.
+
+        Returns:
+            &lt;class &#39;sqlalchemy.orm.decl_api.DeclarativeMeta&#39;&gt;
+        &#34;&#34;&#34;
+        json_cls_schema = {&#34;tablename&#34;: schema_name, &#34;columns&#34;: []}
+
+        for col, dtype in schema_dict.items():
+            new_col = {&#34;name&#34;: col}
+
+            if dtype in _type_lookup:
+                new_col.update({&#34;name&#34;: col, &#34;type&#34;: _type_lookup[dtype]})
+                json_cls_schema[&#34;columns&#34;].append(new_col)
+
+        class_name = &#34;&#34;.join(x.capitalize() or &#34;_&#34; for x in schema_name.split(&#34;_&#34;)) + &#34;Model&#34;
+
+        class_dict = {&#34;clsname&#34;: class_name, &#34;__tablename__&#34;: schema_name, &#34;__table_args__&#34;: {&#34;extend_existing&#34;: True}}
+        class_dict.update({column[&#34;name&#34;]: Column(column[&#34;type&#34;], primary_key=True) if idx == 0 else Column(column[&#34;type&#34;]) for idx, column in enumerate(json_cls_schema[&#34;columns&#34;])})
+        generated_model = type(class_dict[&#34;clsname&#34;], (Base,), class_dict)
+        return generated_model
+
+    @staticmethod
     def _get_table_columns(model):
         if model:
-            return list(model.__table__.columns)
+            tables_colums = []
+            for col in list(model.__table__.columns):
+                tables_colums.append(getattr(model, col.name))
+            return tables_colums
+            # return list(model.__table__.columns)
         raise ValueError(&#34;A model must be provided&#34;)
 
     @staticmethod
@@ -1696,7 +1776,6 @@ Kafka topic.</p>
             query = query.with_session(session).statement
         return pd.read_sql(sql=query, con=session.get_bind(), **options)
 
-    @allow_options({&#34;model&#34;})
     def _write_to_postgres(self, df: pd.DataFrame):
         &#34;&#34;&#34;Write a dataframe to postgres based on the {file_type} of the config_io configuration.
 
@@ -1716,8 +1795,15 @@ Kafka topic.</p>
 
         connection_string = f&#34;postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}&#34;
 
+        if self.options.get(&#34;model&#34;):
+            raise ValueError(&#34;`model` must not be provided&#34;)
+
+        schema_dict = self.sources_config[&#34;schema&#34;]
+        schema_name = self.sources_config[&#34;name&#34;]
+        model = self._generate_model_from_schema(schema_dict, schema_name)
+
         with session_for(connection_string) as session:
-            self._write_to_database(session, self.options[&#34;model&#34;].__tablename__, df)  # type: ignore
+            self._write_to_database(session, model.__tablename__, df)  # type: ignore
 
     @staticmethod
     def _write_to_database(session: SqlAlchemySession, table_name: str, df: pd.DataFrame):

--- a/docs/mixins.html
+++ b/docs/mixins.html
@@ -730,6 +730,7 @@ class WithPostgres:
     @staticmethod
     def _generate_model_from_schema(schema_dict, schema_name):
         &#34;&#34;&#34;Generates a model from a schema loaded from yaml file.
+
         Args:
             schema_dict&lt;dict&gt;: A dictionary from source_config variable containing
                                 columns and their types
@@ -1722,6 +1723,7 @@ Kafka topic.</p>
     @staticmethod
     def _generate_model_from_schema(schema_dict, schema_name):
         &#34;&#34;&#34;Generates a model from a schema loaded from yaml file.
+
         Args:
             schema_dict&lt;dict&gt;: A dictionary from source_config variable containing
                                 columns and their types

--- a/docs/mixins.html
+++ b/docs/mixins.html
@@ -59,17 +59,27 @@ from fastparquet import ParquetFile, write  # type: ignore
 from kafka import KafkaProducer  # type: ignore
 from magic_logger import logger
 from pyarrow.parquet import read_table, write_table  # type: ignore # pylint: disable=no-name-in-module
-from sqlalchemy import Boolean, Column, Float, Integer, String, create_engine  # type: ignore
+from sqlalchemy import BigInteger, Boolean, Column, Date, DateTime, Float, Integer, String, create_engine  # type: ignore
 from sqlalchemy.ext.declarative import declarative_base  # type: ignore
-from sqlalchemy.orm.decl_api import DeclarativeMeta  # type: ignore
 from sqlalchemy.orm import Query  # type: ignore
+from sqlalchemy.orm.decl_api import DeclarativeMeta  # type: ignore
 from sqlalchemy.orm.session import Session as SqlAlchemySession  # type: ignore
 from sqlalchemy.orm.session import sessionmaker  # type: ignore
 
 Session = sessionmaker(autoflush=True)
 
 Base = declarative_base()
-_type_lookup = {&#34;boolean&#34;: Boolean, &#34;object&#34;: String(64), &#34;int64&#34;: Integer, &#34;float64&#34;: Float, &#34;int&#34;: Integer}
+_type_lookup = {
+    &#34;bool&#34;: Boolean,
+    &#34;boolean&#34;: Boolean,
+    &#34;object&#34;: String(64),
+    &#34;int64&#34;: Integer,
+    &#34;float64&#34;: Float,
+    &#34;int&#34;: Integer,
+    &#34;date&#34;: Date,
+    &#34;datetime64[ns]&#34;: DateTime,
+    &#34;bigint&#34;: BigInteger,
+}
 
 
 @contextmanager

--- a/dynamicio/config.py
+++ b/dynamicio/config.py
@@ -199,6 +199,7 @@ class IOConfig:
         source_config = self.config[source_key][self.env_identifier]
         if self.config[source_key].get("schema"):
             schema_definition = self._get_schema_definition(source_key)
+            source_config["name"] = schema_definition["name"]
             source_config["schema"] = self._get_schema(schema_definition)
             source_config["validations"] = self._get_validations(schema_definition)
             source_config["metrics"] = self._get_metrics(schema_definition)

--- a/dynamicio/core.py
+++ b/dynamicio/core.py
@@ -263,8 +263,11 @@ class DynamicDataIO:
             bool - `True` if `df` has the given dtypes, `False` otherwise
         """
         dtypes = df.dtypes
+        print("dtypes: ", dtypes)
+        print("\ndf:", df)
 
         for column_name, expected_dtype in self.schema.items():
+            print(f"\n{column_name} ---- {expected_dtype}")
             found_dtype = dtypes[column_name].name
             if found_dtype != expected_dtype:
                 if self.show_casting_warnings:

--- a/dynamicio/mixins.py
+++ b/dynamicio/mixins.py
@@ -30,7 +30,7 @@ from fastparquet import ParquetFile, write  # type: ignore
 from kafka import KafkaProducer  # type: ignore
 from magic_logger import logger
 from pyarrow.parquet import read_table, write_table  # type: ignore # pylint: disable=no-name-in-module
-from sqlalchemy import Boolean, Column, Float, Integer, String, create_engine  # type: ignore
+from sqlalchemy import BigInteger, Boolean, Column, Date, DateTime, Float, Integer, String, create_engine  # type: ignore
 from sqlalchemy.ext.declarative import declarative_base  # type: ignore
 from sqlalchemy.orm import Query  # type: ignore
 from sqlalchemy.orm.decl_api import DeclarativeMeta  # type: ignore
@@ -40,7 +40,17 @@ from sqlalchemy.orm.session import sessionmaker  # type: ignore
 Session = sessionmaker(autoflush=True)
 
 Base = declarative_base()
-_type_lookup = {"boolean": Boolean, "object": String(64), "int64": Integer, "float64": Float, "int": Integer}
+_type_lookup = {
+    "bool": Boolean,
+    "boolean": Boolean,
+    "object": String(64),
+    "int64": Integer,
+    "float64": Float,
+    "int": Integer,
+    "date": Date,
+    "datetime64[ns]": DateTime,
+    "bigint": BigInteger,
+}
 
 
 @contextmanager

--- a/dynamicio/mixins.py
+++ b/dynamicio/mixins.py
@@ -30,12 +30,16 @@ from fastparquet import ParquetFile, write  # type: ignore
 from kafka import KafkaProducer  # type: ignore
 from magic_logger import logger
 from pyarrow.parquet import read_table, write_table  # type: ignore # pylint: disable=no-name-in-module
-from sqlalchemy import create_engine  # type: ignore
+from sqlalchemy import Boolean, Column, Float, Integer, String, create_engine  # type: ignore
+from sqlalchemy.ext.declarative import declarative_base  # type: ignore
 from sqlalchemy.orm import Query  # type: ignore
 from sqlalchemy.orm.session import Session as SqlAlchemySession  # type: ignore
 from sqlalchemy.orm.session import sessionmaker  # type: ignore
 
 Session = sessionmaker(autoflush=True)
+
+Base = declarative_base()
+_type_lookup = {"boolean": Boolean, "object": String(64), "int64": Integer, "float64": Float, "int": Integer}
 
 
 @contextmanager
@@ -672,28 +676,64 @@ class WithPostgres:
 
         connection_string = f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
 
-        model = self.options.get("model")
         sql_query = self.options.get("sql_query")
 
         query = None
 
-        if model and sql_query:
-            raise ValueError("Only one of `model` and `sql_query` must be provided")
-        if model is None and sql_query is None:
-            raise ValueError("One of `model` and `sql_query` must be provided")
+        if self.options.get("model"):
+            raise ValueError("`model` must not be provided")
 
-        if model:
-            query = Query(self._get_table_columns(model))
+        if "schema" not in self.sources_config:
+            schema_dict = self.schema
         else:
+            schema_dict = self.sources_config["schema"]
+        schema_name = self.sources_config["name"]
+
+        model = self._generate_model_from_schema(schema_dict, schema_name)
+
+        query = Query(self._get_table_columns(model))
+        if sql_query:
             query = sql_query
 
         with session_for(connection_string) as session:
             return self._read_database(session, query, **self.options)
 
     @staticmethod
+    def _generate_model_from_schema(schema_dict, schema_name):
+        """Generates a model from a schema loaded from yaml file.
+
+        Args:
+            schema_dict<dict>: A dictionary from source_config variable containing
+                                columns and their types
+            schema_name<string>: Name of the schema from schema yaml file.
+
+        Returns:
+            <class 'sqlalchemy.orm.decl_api.DeclarativeMeta'>
+        """
+        json_cls_schema = {"tablename": schema_name, "columns": []}
+
+        for col, dtype in schema_dict.items():
+            new_col = {"name": col}
+
+            if dtype in _type_lookup:
+                new_col.update({"name": col, "type": _type_lookup[dtype]})
+                json_cls_schema["columns"].append(new_col)
+
+        class_name = "".join(x.capitalize() or "_" for x in schema_name.split("_")) + "Model"
+
+        class_dict = {"clsname": class_name, "__tablename__": schema_name, "__table_args__": {"extend_existing": True}}
+        class_dict.update({column["name"]: Column(column["type"], primary_key=True) if idx == 0 else Column(column["type"]) for idx, column in enumerate(json_cls_schema["columns"])})
+        generated_model = type(class_dict["clsname"], (Base,), class_dict)
+        return generated_model
+
+    @staticmethod
     def _get_table_columns(model):
         if model:
-            return list(model.__table__.columns)
+            tables_colums = []
+            for col in list(model.__table__.columns):
+                tables_colums.append(getattr(model, col.name))
+            return tables_colums
+            # return list(model.__table__.columns)
         raise ValueError("A model must be provided")
 
     @staticmethod
@@ -716,7 +756,6 @@ class WithPostgres:
             query = query.with_session(session).statement
         return pd.read_sql(sql=query, con=session.get_bind(), **options)
 
-    @allow_options({"model"})
     def _write_to_postgres(self, df: pd.DataFrame):
         """Write a dataframe to postgres based on the {file_type} of the config_io configuration.
 
@@ -736,8 +775,15 @@ class WithPostgres:
 
         connection_string = f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
 
+        if self.options.get("model"):
+            raise ValueError("`model` must not be provided")
+
+        schema_dict = self.sources_config["schema"]
+        schema_name = self.sources_config["name"]
+        model = self._generate_model_from_schema(schema_dict, schema_name)
+
         with session_for(connection_string) as session:
-            self._write_to_database(session, self.options["model"].__tablename__, df)  # type: ignore
+            self._write_to_database(session, model.__tablename__, df)  # type: ignore
 
     @staticmethod
     def _write_to_database(session: SqlAlchemySession, table_name: str, df: pd.DataFrame):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import pytest
 
 from dynamicio import WithS3PathPrefix
 from tests import constants
-from tests.mocking.models import ERModel
+from tests.mocking.models import ERModel, PgModel
 
 TEST_SQL_DIR = os.path.dirname(os.path.abspath(__file__)) + "/test_sql/"
 __pickle_loads = pickle.loads
@@ -241,6 +241,7 @@ def expected_s3_csv_local_mapping():
                 "has_no_null_values": {"apply": True, "options": {}},
             },
         },
+        "name": "read_from_s3_csv"
     }
 
 
@@ -273,6 +274,7 @@ def expected_s3_csv_cloud_mapping():
                 "has_no_null_values": {"apply": True, "options": {}},
             },
         },
+        "name": "read_from_s3_csv"
     }
 
 
@@ -376,6 +378,11 @@ def test_df():
 @pytest.fixture(scope="class")
 def expected_columns():
     return [ERModel.id, ERModel.foo, ERModel.bar, ERModel.baz]
+
+
+@pytest.fixture(scope="class")
+def model_expected_columns():
+    return [PgModel.id, PgModel.foo, PgModel.bar, PgModel.baz]
 
 
 @pytest.fixture(scope="class")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import pytest
 
 from dynamicio import WithS3PathPrefix
 from tests import constants
-from tests.mocking.models import ERModel, PgModel
+from tests.mocking.models import ERModel
 
 TEST_SQL_DIR = os.path.dirname(os.path.abspath(__file__)) + "/test_sql/"
 __pickle_loads = pickle.loads
@@ -378,11 +378,6 @@ def test_df():
 @pytest.fixture(scope="class")
 def expected_columns():
     return [ERModel.id, ERModel.foo, ERModel.bar, ERModel.baz]
-
-
-@pytest.fixture(scope="class")
-def model_expected_columns():
-    return [PgModel.id, PgModel.foo, PgModel.bar, PgModel.baz]
 
 
 @pytest.fixture(scope="class")

--- a/tests/mocking/io.py
+++ b/tests/mocking/io.py
@@ -104,6 +104,10 @@ class WritePostgresIO(UnifiedIO):
     schema = {"id": "object", "foo": "object", "bar": "int64", "baz": "object"}
 
 
+class WriteExtendedPostgresIO(UnifiedIO):
+    schema = {"id": "object", "foo": "object", "bar": "int64", "start_date": "datetime64[ns]", "active": "bool", "net": "float64"}
+
+
 class WriteKafkaIO(UnifiedIO):
     schema = {"id": "object", "foo": "object", "bar": "int64", "baz": "object"}
 

--- a/tests/mocking/models.py
+++ b/tests/mocking/models.py
@@ -20,3 +20,14 @@ class ERModel(Base):
     foo = Column(String)
     bar = Column(Integer)
     baz = Column(String)
+
+
+clsdict = {
+    "clsname": "PgModel",
+    "__tablename__": "pg",
+    "id": Column(String(64), primary_key=True, nullable=False),
+    "foo": Column(String(64)),
+    "bar": Column(Integer()),
+    "baz": Column(String(64)),
+}
+PgModel = type(clsdict["clsname"], (Base,), clsdict)

--- a/tests/resources/definitions/input.yaml
+++ b/tests/resources/definitions/input.yaml
@@ -170,6 +170,8 @@ READ_FROM_POSTGRES:
       db_name: "[[ DB_NAME ]]"
       db_user: "[[ DB_USER ]]"
       db_password: "[[ DB_PASS ]]"
+  schema:
+    file_path: "[[ TEST_RESOURCES ]]/schemas/pg.yaml"
 
 READ_FROM_KAFKA:
   LOCAL:

--- a/tests/resources/schemas/pg.yaml
+++ b/tests/resources/schemas/pg.yaml
@@ -1,0 +1,40 @@
+---
+name: pg
+columns:
+  id:
+    type: "object"
+    validations:
+      has_no_null_values:
+        apply: true
+        options: {}
+    metrics:
+      - CountsPerLabel
+  foo:
+    type: "object"
+    validations:
+      has_no_null_values:
+        apply: true
+        options: {}
+    metrics:
+      - Max
+      - Min
+  bar:
+    type: "int64"
+    validations:
+      is_greater_than:
+        apply: true
+        options:
+          threshold: 1950
+    metrics: []
+  baz:
+    type: "object"
+    validations:
+      is_between:
+        apply: true
+        options:
+          lower: 0
+          upper: 1000
+    metrics:
+      - Min
+      - Max
+      - Mean

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1989,6 +1989,22 @@ class TestAllowedOptions:
         # Then
         assert expected_s3_csv_df.equals(s3_csv_df)
 
+    @pytest.mark.integration
+    @patch.object(WithPostgres, "_read_database")
+    def test_when_reading_from_postgres_only_the_model_option_is_considered(self, mock__read_database, test_df):
+        # Given
+        # VALID OPTION: model=ERModel
+        mock__read_database.return_value = test_df
+        postgres_config = IOConfig(
+            path_to_source_yaml=(os.path.join(constants.TEST_RESOURCES, "definitions/input.yaml")),
+            env_identifier="CLOUD",
+            dynamic_vars=constants,
+        ).get(source_key="READ_FROM_POSTGRES")
+
+        # When / Then
+        with pytest.raises(ValueError):
+            ReadPostgresIO(source_config=postgres_config, model=ERModel).read()
+
 
 class TestBatchLocal:
     @pytest.mark.unit


### PR DESCRIPTION
## Overview

Support for dynamicio to be able to read input data model schema from the [schema yml files](https://github.com/miodo/dynamicio/blob/3694785473/demo/resources/schemas/input/bar.yaml), rather than explicitly defining the schema class as per Issue-https://github.com/VorTECHsa/dynamicio/issues/6

## Key Changes

* Added _generate_model_from_schema method to `dynamicio/mixins.py`
* Removed BarDataModel class in demo/src/io.py
* Removed model argument when reading postgres

## Impact

* `Added support to read data model from schema yml files when reading postgres--> feature`

## Checklist

- [x] Appropriate unit tests added/updated
- [x] Module, function, class docstrings updated
- [x] Interface documentation updated
