### PR TITLE
refactor: Remove boiler plate code for IO classes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -334,7 +334,7 @@ indent-string='    '
 max-line-length=185
 
 # Maximum number of lines in a module.
-max-module-lines=1000
+max-module-lines=1500
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.

--- a/demo/src/io.py
+++ b/demo/src/io.py
@@ -2,10 +2,9 @@
 # pylint: disable=too-few-public-methods
 __all__ = ["InputIO", "StagedFoo", "StagedBar"]
 
-from sqlalchemy import Column, Float, String
 from sqlalchemy.ext.declarative import declarative_base
 
-from dynamicio import UnifiedIO, WithKafka, WithLocal, WithPostgres, WithS3File
+from dynamicio import UnifiedIO, WithLocal, WithPostgres, WithS3File
 from dynamicio.core import SCHEMA_FROM_FILE, DynamicDataIO
 
 Base = declarative_base()

--- a/demo/src/io.py
+++ b/demo/src/io.py
@@ -1,6 +1,6 @@
 """Responsible for configuring io operations for input data."""
 # pylint: disable=too-few-public-methods
-__all__ = ["Foo", "Bar", "StagedFoo", "StagedBar", "FinalFoo", "FinalBar"]
+__all__ = ["InputIO", "StagedFoo", "StagedBar"]
 
 from sqlalchemy import Column, Float, String
 from sqlalchemy.ext.declarative import declarative_base
@@ -11,20 +11,14 @@ from dynamicio.core import SCHEMA_FROM_FILE, DynamicDataIO
 Base = declarative_base()
 
 
-class Foo(UnifiedIO):
+class InputIO(UnifiedIO):
     """UnifiedIO subclass for V6 data."""
 
     schema = SCHEMA_FROM_FILE
 
 
-class Bar(UnifiedIO):
-    """UnifiedIO subclass for cargo movements volumes data."""
-
-    schema = SCHEMA_FROM_FILE
-
-
 class StagedFoo(WithS3File, WithLocal, DynamicDataIO):
-    """UnifiedIO subclass for staged foos6."""
+    """UnifiedIO subclass for staged foos."""
 
     schema = {
         "column_a": "object",
@@ -43,15 +37,3 @@ class StagedBar(WithLocal, WithPostgres, DynamicDataIO):
         "column_c": "int64",
         "column_d": "int64",
     }
-
-
-class FinalFoo(UnifiedIO):
-    """UnifiedIO subclass for V6 data."""
-
-    schema = SCHEMA_FROM_FILE
-
-
-class FinalBar(WithLocal, WithKafka, DynamicDataIO):
-    """UnifiedIO subclass for cargo movements volumes data."""
-
-    schema = SCHEMA_FROM_FILE

--- a/demo/src/runners/staging.py
+++ b/demo/src/runners/staging.py
@@ -2,7 +2,7 @@
 import logging
 
 from demo.src import constants, input_config, raw_config
-from demo.src.io import Bar, Foo, StagedBar, StagedFoo
+from demo.src.io import InputIO, StagedBar, StagedFoo
 
 logger = logging.getLogger(__name__)
 
@@ -16,8 +16,8 @@ def main() -> None:
     # LOAD DATA
     logger.info("Loading data from live sources...")
 
-    bar_df = Bar(source_config=input_config.get(source_key="BAR"), apply_schema_validations=True, log_schema_metrics=True).read()
-    foo_df = Foo(source_config=input_config.get(source_key="FOO"), apply_schema_validations=True, log_schema_metrics=True).read()
+    bar_df = InputIO(source_config=input_config.get(source_key="BAR"), apply_schema_validations=True, log_schema_metrics=True).read()
+    foo_df = InputIO(source_config=input_config.get(source_key="FOO"), apply_schema_validations=True, log_schema_metrics=True).read()
 
     logger.info("Data successfully loaded from live sources...")
 

--- a/demo/src/runners/transform.py
+++ b/demo/src/runners/transform.py
@@ -4,7 +4,7 @@ import logging
 
 import demo.src.environment
 from demo.src import processed_config, raw_config
-from demo.src.io import FinalBar, FinalFoo, StagedBar, StagedFoo
+from demo.src.io import InputIO, StagedBar, StagedFoo
 
 logger = logging.getLogger(__name__)
 
@@ -19,8 +19,7 @@ async def main() -> None:
     logger.info("Loading data from live sources...")
 
     [bar_df, foo_df] = await asyncio.gather(
-        StagedBar(source_config=raw_config.get(source_key="STAGED_BAR")).async_read(),
-        StagedFoo(source_config=raw_config.get(source_key="STAGED_FOO")).async_read()
+        StagedBar(source_config=raw_config.get(source_key="STAGED_BAR")).async_read(), StagedFoo(source_config=raw_config.get(source_key="STAGED_FOO")).async_read()
     )
 
     logger.info("Data successfully loaded from live sources...")
@@ -35,7 +34,7 @@ async def main() -> None:
     # SINK DATA
     logger.info(f"Begin sinking data to staging area: S3:{demo.src.environment.S3_YOUR_OUTPUT_BUCKET}:live/data/raw")
     await asyncio.gather(
-        FinalFoo(source_config=processed_config.get(source_key="FINAL_FOO"), apply_schema_validations=True, log_schema_metrics=True).async_write(foo_df),
-        FinalBar(source_config=processed_config.get(source_key="FINAL_BAR"), apply_schema_validations=True, log_schema_metrics=True).async_write(bar_df),
+        InputIO(source_config=processed_config.get(source_key="FINAL_FOO"), apply_schema_validations=True, log_schema_metrics=True).async_write(foo_df),
+        InputIO(source_config=processed_config.get(source_key="FINAL_BAR"), apply_schema_validations=True, log_schema_metrics=True).async_write(bar_df),
     )
     logger.info("Data staging is complete...")

--- a/dynamicio/core.py
+++ b/dynamicio/core.py
@@ -69,7 +69,7 @@ class DynamicDataIO:
             raise TypeError("Abstract class DynamicDataIO cannot be used to instantiate an object...")
 
         self.sources_config = source_config
-        self.name = re.sub(r"(?<!^)(?=[A-Z])", "_", self.__class__.__name__).upper()
+        self.name = self._transform_class_names_to_dataset_names(self.__class__.__name__)
         self.apply_schema_validations = apply_schema_validations
         self.log_schema_metrics = log_schema_metrics
         self.show_casting_warnings = show_casting_warnings
@@ -226,6 +226,16 @@ class DynamicDataIO:
         if not self._has_valid_dtypes(df):
             raise ColumnsDataTypeError()
         return df
+
+    @staticmethod
+    def _transform_class_names_to_dataset_names(string_to_transform: str) -> str:
+        """Called by the __innit__ function to fetch dataset names from class name.
+
+        Used to create dataset names from class names, turns camel case into upper snake case.
+        For example: 'ThisNameABC' -> 'THIS_NAME_ABC'.
+        """
+        words = re.findall(r"\d[A-Z]+|[A-Z]?[a-z\d]+|[A-Z]{2,}(?=[A-Z][a-z]|\d|\W|$)|\d+|[A-Z]{2,}|[A-Z]", string_to_transform)
+        return "_".join(map(str.lower, words)).upper()
 
     def _has_valid_dtypes(self, df: pd.DataFrame) -> bool:
         """Checks if `df` has the expected dtypes defined in `schema`.

--- a/dynamicio/core.py
+++ b/dynamicio/core.py
@@ -69,7 +69,7 @@ class DynamicDataIO:
             raise TypeError("Abstract class DynamicDataIO cannot be used to instantiate an object...")
 
         self.sources_config = source_config
-        self.name = self._transform_class_names_to_dataset_names(self.__class__.__name__)
+        self.name = self._transform_class_name_to_dataset_name(self.__class__.__name__)
         self.apply_schema_validations = apply_schema_validations
         self.log_schema_metrics = log_schema_metrics
         self.show_casting_warnings = show_casting_warnings
@@ -228,10 +228,10 @@ class DynamicDataIO:
         return df
 
     @staticmethod
-    def _transform_class_names_to_dataset_names(string_to_transform: str) -> str:
-        """Called by the __innit__ function to fetch dataset names from class name.
+    def _transform_class_name_to_dataset_name(string_to_transform: str) -> str:
+        """Called by the init function to fetch dataset names from class name.
 
-        Used to create dataset names from class names, turns camel case into upper snake case.
+        Used to create dataset name from class name, turns camel case into upper snake case.
         For example: 'ThisNameABC' -> 'THIS_NAME_ABC'.
         """
         words = re.findall(r"\d[A-Z]+|[A-Z]?[a-z\d]+|[A-Z]{2,}(?=[A-Z][a-z]|\d|\W|$)|\d+|[A-Z]{2,}|[A-Z]", string_to_transform)

--- a/dynamicio/core.py
+++ b/dynamicio/core.py
@@ -4,6 +4,7 @@ __all__ = ["DynamicDataIO", "SCHEMA_FROM_FILE"]
 
 import asyncio
 import inspect
+import re
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Mapping, MutableMapping, Optional
 
@@ -11,16 +12,7 @@ import pandas as pd  # type: ignore
 from magic_logger import logger
 
 from dynamicio import validations
-from dynamicio.errors import (
-    ADVICE_MSG,
-    CASTING_WARNING_MSG,
-    NOTICE_MSG,
-    ColumnsDataTypeError,
-    CustomValidationError,
-    MissingSchemaDefinition,
-    SchemaNotFoundError,
-    SchemaValidationError,
-)
+from dynamicio.errors import CASTING_WARNING_MSG, NOTICE_MSG, ColumnsDataTypeError, MissingSchemaDefinition, SchemaNotFoundError, SchemaValidationError
 from dynamicio.metrics import get_metric
 
 SCHEMA_FROM_FILE = {"schema": object()}
@@ -77,6 +69,7 @@ class DynamicDataIO:
             raise TypeError("Abstract class DynamicDataIO cannot be used to instantiate an object...")
 
         self.sources_config = source_config
+        self.name = re.sub(r"(?<!^)(?=[A-Z])", "_", self.__class__.__name__).upper()
         self.apply_schema_validations = apply_schema_validations
         self.log_schema_metrics = log_schema_metrics
         self.show_casting_warnings = show_casting_warnings
@@ -85,6 +78,7 @@ class DynamicDataIO:
         if self.schema is SCHEMA_FROM_FILE:
             try:
                 self.schema = self.sources_config["schema"]
+                self.name = self.sources_config["name"].upper()
                 self.schema_validations = self.sources_config["validations"]
                 self.schema_metrics = self.sources_config["metrics"]
             except KeyError as _error:
@@ -124,9 +118,6 @@ class DynamicDataIO:
         source_name = self.sources_config.get("type")
         df = getattr(self, f"_read_from_{source_name}")()
 
-        if not self.validate(df):
-            raise CustomValidationError("User-defined validation has failed!")
-
         df = self._apply_schema(df)
         if self.apply_schema_validations:
             self.validate_from_schema(df)
@@ -154,9 +145,6 @@ class DynamicDataIO:
         if set(list(df.columns)) != set(self.schema.keys()):  # pylint: disable=E1101
             columns = [column for column in df.columns.to_list() if column in self.schema.keys()]
             df = df[columns]
-
-        if not self.validate(df):
-            raise CustomValidationError("User-defined validation has failed!")
 
         if self.apply_schema_validations:
             self.validate_from_schema(df)
@@ -189,7 +177,7 @@ class DynamicDataIO:
             for validation in self.schema_validations[column].keys():
                 if self.schema_validations[column][validation]["apply"] is True:
                     validation_result = getattr(validations, validation)(
-                        self.__class__.__name__,
+                        self.name,
                         df,
                         column,
                         **self.schema_validations[column][validation]["options"],
@@ -216,35 +204,9 @@ class DynamicDataIO:
 
         for column in self.schema_metrics.keys():
             for metric in self.schema_metrics[column]:
-                get_metric(metric)(self.__class__.__name__, df, column)()  # type: ignore
+                get_metric(metric)(self.name, df, column)()  # type: ignore
 
         return self
-
-    @staticmethod
-    def validate(df: pd.DataFrame) -> bool:  # pylint: disable=W0613
-        """Abstract method used as part of the I/O logic.
-
-        This method should be overriden by the a user defined one, when the user wants to intervene to the I/O logic.
-
-        Example:
-           >>> class Foo(UnifiedIO):
-           >>>    schema = SCHEMA_FROM_FILE
-           >>>
-           >>>    @staticmethod
-           >>>    def validate(df: pd.DataFrame):
-           >>>       return df["col_a"].isna().sum() == 0
-           >>>
-           >>>
-           >>>
-           >>>  df = Foo(source_config=input_config.get(source_key="FOO")).read())
-           >>>
-        Args:
-            df: A pandas dataframe.
-
-        Returns:
-            True if validations pass and false otherwise.
-        """
-        return True
 
     def _apply_schema(self, df: pd.DataFrame) -> pd.DataFrame:
         """Called by the `self.read()` and the `self._write_to_local()` methods.
@@ -287,15 +249,14 @@ class DynamicDataIO:
             found_dtype = dtypes[column_name].name
             if found_dtype != expected_dtype:
                 if self.show_casting_warnings:
-                    logger.info(f"Expected: '{expected_dtype}' dtype for {self.__class__.__name__}['{column_name}]', found '{found_dtype}'")
+                    logger.info(f"Expected: '{expected_dtype}' dtype for {self.name}['{column_name}]', found '{found_dtype}'")
                 try:
                     if len(set([type(v) for v in df[column_name].values])) > 1:  # pylint: disable=consider-using-set-comprehension
                         logger.warning(CASTING_WARNING_MSG.format(column_name, expected_dtype, found_dtype))  # pylint: disable=logging-format-interpolation
                         logger.info(NOTICE_MSG.format(column_name))  # pylint: disable=logging-format-interpolation
-                        logger.info(ADVICE_MSG)
                     df.loc[:, column_name] = df[column_name].astype(self.schema[column_name])
                 except (ValueError, TypeError):
-                    logger.error(f"ValueError: Tried casting column {self.__class__.__name__}['{column_name}]' to '{expected_dtype}' " f"from '{found_dtype}', but failed")
+                    logger.error(f"ValueError: Tried casting column {self.name}['{column_name}]' to '{expected_dtype}' " f"from '{found_dtype}', but failed")
                     return False
         return True
 

--- a/dynamicio/errors.py
+++ b/dynamicio/errors.py
@@ -10,9 +10,7 @@ __all__ = [
     "MissingSchemaDefinition",
     "SchemaNotFoundError",
     "SchemaValidationError",
-    "CustomValidationError",
     "InvalidDatasetTypeError",
-    "ADVICE_MSG",
     "CASTING_WARNING_MSG",
     "NOTICE_MSG",
 ]
@@ -59,10 +57,6 @@ class SchemaValidationError(DynamicIOError):
     """Error raised when schema validation fails."""
 
 
-class CustomValidationError(DynamicIOError):
-    """Error raised when user-defined validation fails."""
-
-
 class MissingSchemaDefinition(DynamicIOError):
     """Error raised when schema is not specified in the provided source."""
 
@@ -100,4 +94,3 @@ class InvalidDatasetTypeError(DynamicIOError):
 # Warning messages
 CASTING_WARNING_MSG = "Applying casting column: '{0}' to: 'type:{1}' from 'type:{2}' though not advised, as `dtypes`>1 for {0}, which may lead to data corruption!"
 NOTICE_MSG = "Keeping the {0} as is, may anyway cause I/O errors or data corruption issues especially when using `pandas.DataFrame.to_parquet` or `pandas.DataFrame.to_json`."
-ADVICE_MSG = "Use the `dynamicio.core.DynamicDataIO.validate()` through your `dynamicio.UnifiedIO` instance to apply custom validations as part of this I/O operation."

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,7 +13,7 @@ import pytest
 import dynamicio
 from dynamicio.config import IOConfig
 from dynamicio.core import CASTING_WARNING_MSG, DynamicDataIO
-from dynamicio.errors import ColumnsDataTypeError, CustomValidationError, MissingSchemaDefinition, SchemaNotFoundError, SchemaValidationError
+from dynamicio.errors import ColumnsDataTypeError, MissingSchemaDefinition, SchemaNotFoundError, SchemaValidationError
 from dynamicio.mixins import WithS3File
 from tests import constants
 from tests.mocking.io import (
@@ -250,16 +250,16 @@ class TestCoreIO:
         assert (
             io_instance is return_value
             and (len(caplog.records) == 10)
-            and (getattr(caplog.records[0], "message") == '{"message": "METRIC", "dataset": "ReadS3CsvIO", "column": "id", "metric": "UniqueCounts", "value": 4.0}')
-            and (getattr(caplog.records[1], "message") == '{"message": "METRIC", "dataset": "ReadS3CsvIO", "column": "id", "metric": "Counts", "value": 4.0}')
-            and (getattr(caplog.records[2], "message") == '{"message": "METRIC", "dataset": "ReadS3CsvIO", "column": "foo_name-class_a", "metric": "CountsPerLabel", "value": 2.0}')
-            and (getattr(caplog.records[3], "message") == '{"message": "METRIC", "dataset": "ReadS3CsvIO", "column": "foo_name-class_b", "metric": "CountsPerLabel", "value": 1.0}')
-            and (getattr(caplog.records[4], "message") == '{"message": "METRIC", "dataset": "ReadS3CsvIO", "column": "foo_name-class_c", "metric": "CountsPerLabel", "value": 1.0}')
-            and (getattr(caplog.records[5], "message") == '{"message": "METRIC", "dataset": "ReadS3CsvIO", "column": "bar", "metric": "Min", "value": 1500.0}')
-            and (getattr(caplog.records[6], "message") == '{"message": "METRIC", "dataset": "ReadS3CsvIO", "column": "bar", "metric": "Max", "value": 1500.0}')
-            and (getattr(caplog.records[7], "message") == '{"message": "METRIC", "dataset": "ReadS3CsvIO", "column": "bar", "metric": "Mean", "value": 1500.0}')
-            and (getattr(caplog.records[8], "message") == '{"message": "METRIC", "dataset": "ReadS3CsvIO", "column": "bar", "metric": "Std", "value": 0.0}')
-            and (getattr(caplog.records[9], "message") == '{"message": "METRIC", "dataset": "ReadS3CsvIO", "column": "bar", "metric": "Variance", "value": 0.0}')
+            and (getattr(caplog.records[0], "message") == '{"message": "METRIC", "dataset": "READ_FROM_S3_CSV", "column": "id", "metric": "UniqueCounts", "value": 4.0}')
+            and (getattr(caplog.records[1], "message") == '{"message": "METRIC", "dataset": "READ_FROM_S3_CSV", "column": "id", "metric": "Counts", "value": 4.0}')
+            and (getattr(caplog.records[2], "message") == '{"message": "METRIC", "dataset": "READ_FROM_S3_CSV", "column": "foo_name-class_a", "metric": "CountsPerLabel", "value": 2.0}')
+            and (getattr(caplog.records[3], "message") == '{"message": "METRIC", "dataset": "READ_FROM_S3_CSV", "column": "foo_name-class_b", "metric": "CountsPerLabel", "value": 1.0}')
+            and (getattr(caplog.records[4], "message") == '{"message": "METRIC", "dataset": "READ_FROM_S3_CSV", "column": "foo_name-class_c", "metric": "CountsPerLabel", "value": 1.0}')
+            and (getattr(caplog.records[5], "message") == '{"message": "METRIC", "dataset": "READ_FROM_S3_CSV", "column": "bar", "metric": "Min", "value": 1500.0}')
+            and (getattr(caplog.records[6], "message") == '{"message": "METRIC", "dataset": "READ_FROM_S3_CSV", "column": "bar", "metric": "Max", "value": 1500.0}')
+            and (getattr(caplog.records[7], "message") == '{"message": "METRIC", "dataset": "READ_FROM_S3_CSV", "column": "bar", "metric": "Mean", "value": 1500.0}')
+            and (getattr(caplog.records[8], "message") == '{"message": "METRIC", "dataset": "READ_FROM_S3_CSV", "column": "bar", "metric": "Std", "value": 0.0}')
+            and (getattr(caplog.records[9], "message") == '{"message": "METRIC", "dataset": "READ_FROM_S3_CSV", "column": "bar", "metric": "Variance", "value": 0.0}')
         )
 
     @pytest.mark.integration
@@ -770,21 +770,6 @@ class TestCoreIO:
         finally:
             os.remove(s3_parquet_with_some_bool_col_local_config["local"]["file_path"])
 
-    @pytest.mark.unit
-    def test_if_custom_validate_method_is_used_and_fails_then_custom_validation_error_is_thrown(self):
-
-        # Given
-        df = pd.DataFrame.from_records([{"id": 1, "foo_name": "A", "bar": 12, "bool_col": True}, {"id": 1, "foo_name": "B", "bar": None, "bool_col": False}])
-        s3_parquet_with_some_bool_col_local_config = IOConfig(
-            path_to_source_yaml=(os.path.join(constants.TEST_RESOURCES, "definitions/input.yaml")),
-            env_identifier="LOCAL",
-            dynamic_vars=constants,
-        ).get(source_key="S3_PARQUET_WITH_CUSTOM_VALIDATE")
-
-        # When
-        with pytest.raises(CustomValidationError):
-            ParquetWithCustomValidate(source_config=s3_parquet_with_some_bool_col_local_config).write(df)
-
     @pytest.mark.integration
     def test_show_casting_warnings_flag_default_value_prevents_showing_casting_logs(self, caplog):
         # Given
@@ -817,7 +802,7 @@ class TestCoreIO:
             io_instance.read()
 
         # Then
-        assert getattr(caplog.records[0], "message") == "Expected: 'float64' dtype for ReadS3DataWithFalseTypes['id]', found 'int64'"
+        assert getattr(caplog.records[0], "message") == "Expected: 'float64' dtype for READ_S3_DATA_WITH_FALSE_TYPES['id]', found 'int64'"
 
     @pytest.mark.unit
     def test_options_are_read_from_code(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -897,6 +897,22 @@ class TestCoreIO:
         # Then
         assert config_io.name == "READ_S3_PARQUET_I_O"
 
+    @pytest.mark.unit
+    def test_dataset_name_is_inferred_from_schema_if_schema_from_file_is_provided(self):
+
+        # Given
+        s3_parquet_local_config = IOConfig(
+            path_to_source_yaml=(os.path.join(constants.TEST_RESOURCES, "definitions/input.yaml")),
+            env_identifier="LOCAL",
+            dynamic_vars=constants,
+        ).get(source_key="READ_FROM_S3_CSV")
+
+        # When
+        config_io = ReadS3CsvIO(source_config=s3_parquet_local_config)
+
+        # Then
+        assert config_io.name == "READ_FROM_S3_CSV"
+
 
 class TestAsyncCoreIO:
     @pytest.mark.unit

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -901,14 +901,14 @@ class TestCoreIO:
     def test_dataset_name_is_inferred_from_schema_if_schema_from_file_is_provided(self):
 
         # Given
-        s3_parquet_local_config = IOConfig(
+        s3_read_from_csv_config = IOConfig(
             path_to_source_yaml=(os.path.join(constants.TEST_RESOURCES, "definitions/input.yaml")),
             env_identifier="LOCAL",
             dynamic_vars=constants,
         ).get(source_key="READ_FROM_S3_CSV")
 
         # When
-        config_io = ReadS3CsvIO(source_config=s3_parquet_local_config)
+        config_io = ReadS3CsvIO(source_config=s3_read_from_csv_config)
 
         # Then
         assert config_io.name == "READ_FROM_S3_CSV"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -866,14 +866,21 @@ class TestCoreIO:
         assert config_io.options == {"option_1": False, "option_2": True, "option_3": True, "option_4": True}
 
     @pytest.mark.unit
-    def test_transform_class_names_to_dataset_names(self):
-        # Given
-        camel_case_strings = ["TestStringABC", "TestString", "ThisIsAnotherTest", "AbstractS3Test", "YetAnotherGREATTest"]
-        # When
-        transformed_strings = [DynamicDataIO._transform_class_name_to_dataset_name(s) for s in camel_case_strings]  # pylint: disable=W0212
-        expected_strings = ["TEST_STRING_ABC", "TEST_STRING", "THIS_IS_ANOTHER_TEST", "ABSTRACT_S3_TEST", "YET_ANOTHER_GREAT_TEST"]
+    @pytest.mark.parametrize(
+        "camel_case_string, expected_string",
+        [
+            ("TestStringABC", "TEST_STRING_ABC"),
+            ("TestString", "TEST_STRING"),
+            ("ThisIsAnotherTest", "THIS_IS_ANOTHER_TEST"),
+            ("AbstractS3Test", "ABSTRACT_S3_TEST"),
+            ("YetAnotherGREATTest", "YET_ANOTHER_GREAT_TEST"),
+        ],
+    )
+    def test_transform_class_names_to_dataset_names(self, camel_case_string, expected_string):
+        # Given/When
+        transformed_string = DynamicDataIO._transform_class_name_to_dataset_name(camel_case_string)  # pylint: disable=W0212
 
-        assert transformed_strings == expected_strings
+        assert transformed_string == expected_string
 
     @pytest.mark.unit
     def test_no_options_at_all_are_provided_with_no_issues(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -866,6 +866,16 @@ class TestCoreIO:
         assert config_io.options == {"option_1": False, "option_2": True, "option_3": True, "option_4": True}
 
     @pytest.mark.unit
+    def test_transform_class_names_to_dataset_names(self):
+        # Given
+        camel_case_strings = ["TestStringABC", "TestString", "ThisIsAnotherTest", "AbstractS3Test", "YetAnotherGREATTest"]
+        # When
+        transformed_strings = [DynamicDataIO._transform_class_names_to_dataset_names(s) for s in camel_case_strings]  # pylint: disable=W0212
+        expected_strings = ["TEST_STRING_ABC", "TEST_STRING", "THIS_IS_ANOTHER_TEST", "ABSTRACT_S3_TEST", "YET_ANOTHER_GREAT_TEST"]
+
+        assert transformed_strings == expected_strings
+
+    @pytest.mark.unit
     def test_no_options_at_all_are_provided_with_no_issues(self):
 
         # Given
@@ -895,7 +905,7 @@ class TestCoreIO:
         config_io = ReadS3ParquetIO(source_config=s3_parquet_local_config)
 
         # Then
-        assert config_io.name == "READ_S3_PARQUET_I_O"
+        assert config_io.name == "READ_S3_PARQUET_IO"
 
     @pytest.mark.unit
     def test_dataset_name_is_inferred_from_schema_if_schema_from_file_is_provided(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -881,6 +881,22 @@ class TestCoreIO:
         # Then
         assert config_io.options == {}
 
+    @pytest.mark.unit
+    def test_dataset_name_is_defined_by_io_class_if_schema_from_file_is_not_provided(self):
+
+        # Given
+        s3_parquet_local_config = IOConfig(
+            path_to_source_yaml=(os.path.join(constants.TEST_RESOURCES, "definitions/input.yaml")),
+            env_identifier="LOCAL",
+            dynamic_vars=constants,
+        ).get(source_key="READ_FROM_S3_PARQUET")
+
+        # When
+        config_io = ReadS3ParquetIO(source_config=s3_parquet_local_config)
+
+        # Then
+        assert config_io.name == "READ_S3_PARQUET_I_O"
+
 
 class TestAsyncCoreIO:
     @pytest.mark.unit
@@ -921,7 +937,6 @@ class TestAsyncCoreIO:
 
     @pytest.mark.unit
     def test_async_read_does_indeed_operate_in_parallel(self):
-
         # Given
         s3_csv_local_config = IOConfig(
             path_to_source_yaml=(os.path.join(constants.TEST_RESOURCES, "definitions/input.yaml")),
@@ -952,7 +967,6 @@ class TestAsyncCoreIO:
 
     @pytest.mark.unit
     def test_async_write_does_indeed_operate_in_parallel(self):
-
         # Given
         df = pd.DataFrame.from_dict({"id": [3, 2, 1, 0], "foo_name": ["a", "b", "c", "d"], "bar": [1, 2, 3, 4]})
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -870,7 +870,7 @@ class TestCoreIO:
         # Given
         camel_case_strings = ["TestStringABC", "TestString", "ThisIsAnotherTest", "AbstractS3Test", "YetAnotherGREATTest"]
         # When
-        transformed_strings = [DynamicDataIO._transform_class_names_to_dataset_names(s) for s in camel_case_strings]  # pylint: disable=W0212
+        transformed_strings = [DynamicDataIO._transform_class_name_to_dataset_name(s) for s in camel_case_strings]  # pylint: disable=W0212
         expected_strings = ["TEST_STRING_ABC", "TEST_STRING", "THIS_IS_ANOTHER_TEST", "ABSTRACT_S3_TEST", "YET_ANOTHER_GREAT_TEST"]
 
         assert transformed_strings == expected_strings


### PR DESCRIPTION
## Overview

Currently, users of dynamicio are required to create a lot of boilerplate code. [demo/src/io.py](https://github.com/miodo/dynamicio/blob/369478547363f00bb2d0ecbb9737456d931fbabf/demo/src/io.py#L48)

In practice, custom classes that extend UnifiedIO are rarely required.

There's rarely a need for a user to implement the `validate` function. [found here](https://github.com/miodo/dynamicio/blob/369478547363f00bb2d0ecbb9737456d931fbabf/dynamicio/core.py#L205)

We can simplify dynamicio by removing a lot of boilerplate code, (everything below demo/src/io.py IO class)

But, the current implementation is such that the name of the dataset is set to the name of the extension class (like StagedFoo) etc.

- Further details about getting started with dynamicio can be found [here](https://youtu.be/Feh6KyrsFQI) 
- Further details about this task can be found [here](https://youtu.be/Cqpf022S3ic) 

### Task

- [x] Remove validate method from [core.py](https://github.com/miodo/dynamicio/blob/369478547363f00bb2d0ecbb9737456d931fbabf/dynamicio/core.py#L205)
- [x] Name io.py/line 173 don't use class name here anymore, use name from schema file.
### Suggested Approach

- Replace references of class name with references to schema config name.
- Remove `def validate` method, as described in video.

### Acceptance Criteria

- [x] dynamicio uses the schema name rather than extension class name
- [x] `io.py` boilerplate code not required anymore, as discussed in video
- [x] all references to `validate` method are to be removed.
- [x] all existing tests pass
- [x] new tests written as required
- [x] readme & docs are updated to reflect the new changes.

## Optional Below:

- [x] Screenshots of actual interactions with live resources. 
- [x] Performance stats/graphs.

## Release-Steps

- [x] Merge PR
- [x] Release new tag
