### PR TITLE
feat: Extend has equal validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,15 +689,43 @@ They can be automatically applied on loading or on writing out.
 
 Specifically, you can use the following **validations**:
 
-- `has_unique_values`
-- `has_no_null_values`
+- `has_unique_values`  # no options
+- `has_no_null_values`  # no options
 - `has_acceptable_percentage_of_nulls`
-- `has_acceptable_categorical_values`
+- `has_acceptable_categorical_values`:
+  ```yaml
+    validations:
+      has_acceptable_categorical_values:
+        apply: true
+        options:
+          categorical_values:
+            - class_a
+            - class_b
+            - class_c
+          is_subset: false # true by default, if false, then the column unique categoricals must be equal to the acceptable ones, else they must be a subset
+  ```
 - `is_greater_than`
-- `is_greater_than_or_equal`
-- `is_lower_than`
-- `is_lower_than_or_equal`
-- `is_between`
+  ```yaml
+    validations:
+      is_greater_than:
+        apply: true
+        options:
+          threshold: 1000
+  ```
+- `is_greater_than_or_equal`  # same as `is_greater_than`
+- `is_lower_than`  # same as `is_greater_than`
+- `is_lower_than_or_equal`  # same as `is_greater_than`
+- `is_between`  # same as `is_greater_than`
+  ```yaml
+    validations:
+      is_between:
+        apply: true
+        options:
+          lower: 0
+          upper: 1000
+          include_left: false
+          include_right: true # true by default
+  ```
 
 and **metrics**:
 
@@ -709,6 +737,19 @@ and **metrics**:
 - `Counts`
 - `UniqueCounts`
 - `CountsPerLabel`
+
+imposed as per below:
+```shell
+  column_c:
+    type: float64
+    validations: {}
+    metrics:
+      - Min
+      - Max
+      - Mean
+      - Std
+      - ...
+```
 
 Note that you can also use dynamic fields to define validations, e.g. see `LOWER_THAN_LIMIT` in the file below: 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -692,17 +692,17 @@ Specifically, you can use the following **validations**:
 - `has_unique_values`  # no options
 - `has_no_null_values`  # no options
 - `has_acceptable_percentage_of_nulls`
-- `has_acceptable_categorical_values`:
+- `is_in`:
   ```yaml
     validations:
-      has_acceptable_categorical_values:
+      is_in:
         apply: true
         options:
           categorical_values:
             - class_a
             - class_b
             - class_c
-          is_subset: false # true by default, if false, then the column unique categoricals must be equal to the acceptable ones, else they must be a subset
+          match_all: false # true by default, if false, then the column unique categoricals must be equal to the acceptable ones, else they must be a subset
   ```
 - `is_greater_than`
   ```yaml
@@ -959,7 +959,7 @@ and looks like:
 import logging
 
 from demo.src import constants, input_config, raw_config
-from demo.src.io import Bar, BarDataModel, Foo, StagedBar, StagedFoo
+from demo.src.io import InputIO, StagedBar, StagedFoo
 
 logger = logging.getLogger(__name__)
 

--- a/docs/config.html
+++ b/docs/config.html
@@ -128,17 +128,17 @@ would return:
             }
         }
 &#34;&#34;&#34;
-__all__ = [&#34;IOConfig&#34;, &#34;SafeDynamicLoader&#34;]
+__all__ = [&#34;IOConfig&#34;, &#34;SafeDynamicResourceLoader&#34;, &#34;SafeDynamicSchemaLoader&#34;]
 
 import re
 from types import ModuleType
-from typing import List, Mapping
+from typing import Any, List, Mapping
 
 import yaml
 from magic_logger import logger
 
 
-class SafeDynamicLoader(yaml.SafeLoader):
+class SafeDynamicResourceLoader(yaml.SafeLoader):
     &#34;&#34;&#34;Implements a dynamic yaml loader that parses yaml files and replaces strings that map to [[ DYNAMIC_VAR ]].
 
     Dynamic variables defined in a provided module object.
@@ -160,14 +160,14 @@ class SafeDynamicLoader(yaml.SafeLoader):
         return type(f&#34;{cls.__name__}_{module.__name__}&#34;, (cls,), {&#34;module&#34;: module})
 
     def dyn_str_constructor(self, node: yaml.nodes.ScalarNode) -&gt; str:
-        &#34;&#34;&#34;Responsible for the switching of one or more &#34;[[ DYNAMIC_VAR ]]&#34; strings with the respective attributes value in a give module.
+        &#34;&#34;&#34;Responsible for the switching of one or more &#34;[[ DYNAMIC_VAR ]]&#34; strings with the respective attributes value in a given module.
 
         Args:
             node: Parsed item whose dynamic values that map to the &#34;[[ DYNAMIC_VAR ]]&#34; convention
                 are replaced with the respective attributes in te provided module.
 
         Returns:
-            Constructed `str`
+            Constructed `str` or numerical.
         &#34;&#34;&#34;
         value = node.value
 
@@ -177,6 +177,53 @@ class SafeDynamicLoader(yaml.SafeLoader):
 
             value = self.dynamic_data_matcher.sub(f&#34;\\g&lt;1&gt;{replacement}\\g&lt;4&gt;&#34;, value)
 
+        return value
+
+
+class SafeDynamicSchemaLoader(yaml.SafeLoader):
+    &#34;&#34;&#34;Implements a dynamic yaml loader that parses yaml files and replaces strings that map to [[ DYNAMIC_VAR ]].
+
+    Dynamic variables defined in a provided module object.
+    &#34;&#34;&#34;
+
+    module = None
+    dynamic_data_matcher = re.compile(r&#34;(.*)(\[\[\s*(\S+)\s*]])(.*)&#34;)
+
+    @classmethod
+    def with_module(cls, module: ModuleType):
+        &#34;&#34;&#34;Creates a dynamic subclass of SafeDynamicLoader with the `data_module` attribute set to `module`.
+
+        Args:
+            module: A global vars module with all the dynamic values defined in it.
+
+        Returns:
+            type
+        &#34;&#34;&#34;
+        return type(f&#34;{cls.__name__}_{module.__name__}&#34;, (cls,), {&#34;module&#34;: module})
+
+    def dyn_value_constructor(self, node: yaml.nodes.ScalarNode) -&gt; Any:
+        &#34;&#34;&#34;Responsible for the switching of one or more &#34;[[ DYNAMIC_VAR ]]&#34; strings with the respective attributes value in a given module.
+
+        Args:
+            node: Parsed item whose dynamic values that map to the &#34;[[ DYNAMIC_VAR ]]&#34; convention
+                are replaced with the respective attributes in te provided module.
+
+        Returns:
+            Constructed `str` or numerical.
+        &#34;&#34;&#34;
+        value = node.value
+
+        while result := self.dynamic_data_matcher.match(value):
+            ref = result.group(3)
+            replacement = getattr(self.module, ref)
+
+            value = self.dynamic_data_matcher.sub(f&#34;\\g&lt;1&gt;{replacement}\\g&lt;4&gt;&#34;, value)
+
+        try:
+            value = float(value)
+            return value
+        except ValueError:
+            pass
         return value
 
 
@@ -195,7 +242,8 @@ class IOConfig:
     &#34;&#34;&#34;
 
     YAML_TAG = &#34;tag:yaml.org,2002:str&#34;
-    SafeDynamicLoader.add_constructor(YAML_TAG, SafeDynamicLoader.dyn_str_constructor)
+    SafeDynamicResourceLoader.add_constructor(YAML_TAG, SafeDynamicResourceLoader.dyn_str_constructor)
+    SafeDynamicSchemaLoader.add_constructor(YAML_TAG, SafeDynamicSchemaLoader.dyn_value_constructor)
 
     def __init__(self, path_to_source_yaml: str, env_identifier: str, dynamic_vars: ModuleType):
         &#34;&#34;&#34;Class constructor.
@@ -220,7 +268,7 @@ class IOConfig:
         &#34;&#34;&#34;
         with open(self.path_to_source_yaml, &#34;r&#34;) as stream:  # pylint: disable=unspecified-encoding]
             logger.debug(f&#34;Parsing {self.path_to_source_yaml}...&#34;)
-            return yaml.load(stream, SafeDynamicLoader.with_module(self.dynamic_vars))
+            return yaml.load(stream, SafeDynamicResourceLoader.with_module(self.dynamic_vars))
 
     @property
     def sources(self) -&gt; List[str]:
@@ -290,7 +338,7 @@ class IOConfig:
         schema_file_path = self.config[source_key].get(&#34;schema&#34;)[&#34;file_path&#34;]
         with open(schema_file_path, &#34;r&#34;) as stream:  # pylint: disable=unspecified-encoding]
             logger.debug(f&#34;Parsing schema: {schema_file_path}...&#34;)
-            return yaml.load(stream, Loader=yaml.SafeLoader)
+            return yaml.load(stream, SafeDynamicSchemaLoader.with_module(self.dynamic_vars))
 
     @staticmethod
     def _get_schema(schema_definition: Mapping) -&gt; Mapping:
@@ -391,7 +439,8 @@ may reference.</dd>
     &#34;&#34;&#34;
 
     YAML_TAG = &#34;tag:yaml.org,2002:str&#34;
-    SafeDynamicLoader.add_constructor(YAML_TAG, SafeDynamicLoader.dyn_str_constructor)
+    SafeDynamicResourceLoader.add_constructor(YAML_TAG, SafeDynamicResourceLoader.dyn_str_constructor)
+    SafeDynamicSchemaLoader.add_constructor(YAML_TAG, SafeDynamicSchemaLoader.dyn_value_constructor)
 
     def __init__(self, path_to_source_yaml: str, env_identifier: str, dynamic_vars: ModuleType):
         &#34;&#34;&#34;Class constructor.
@@ -416,7 +465,7 @@ may reference.</dd>
         &#34;&#34;&#34;
         with open(self.path_to_source_yaml, &#34;r&#34;) as stream:  # pylint: disable=unspecified-encoding]
             logger.debug(f&#34;Parsing {self.path_to_source_yaml}...&#34;)
-            return yaml.load(stream, SafeDynamicLoader.with_module(self.dynamic_vars))
+            return yaml.load(stream, SafeDynamicResourceLoader.with_module(self.dynamic_vars))
 
     @property
     def sources(self) -&gt; List[str]:
@@ -486,7 +535,7 @@ may reference.</dd>
         schema_file_path = self.config[source_key].get(&#34;schema&#34;)[&#34;file_path&#34;]
         with open(schema_file_path, &#34;r&#34;) as stream:  # pylint: disable=unspecified-encoding]
             logger.debug(f&#34;Parsing schema: {schema_file_path}...&#34;)
-            return yaml.load(stream, Loader=yaml.SafeLoader)
+            return yaml.load(stream, SafeDynamicSchemaLoader.with_module(self.dynamic_vars))
 
     @staticmethod
     def _get_schema(schema_definition: Mapping) -&gt; Mapping:
@@ -661,8 +710,8 @@ voyage_data_cloud_mapping = input_config.get(source_key="VOYAGE_DATA")
 </dd>
 </dl>
 </dd>
-<dt id="dynamicio.config.SafeDynamicLoader"><code class="flex name class">
-<span>class <span class="ident">SafeDynamicLoader</span></span>
+<dt id="dynamicio.config.SafeDynamicResourceLoader"><code class="flex name class">
+<span>class <span class="ident">SafeDynamicResourceLoader</span></span>
 <span>(</span><span>stream)</span>
 </code></dt>
 <dd>
@@ -673,7 +722,7 @@ voyage_data_cloud_mapping = input_config.get(source_key="VOYAGE_DATA")
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">class SafeDynamicLoader(yaml.SafeLoader):
+<pre><code class="python">class SafeDynamicResourceLoader(yaml.SafeLoader):
     &#34;&#34;&#34;Implements a dynamic yaml loader that parses yaml files and replaces strings that map to [[ DYNAMIC_VAR ]].
 
     Dynamic variables defined in a provided module object.
@@ -695,14 +744,14 @@ voyage_data_cloud_mapping = input_config.get(source_key="VOYAGE_DATA")
         return type(f&#34;{cls.__name__}_{module.__name__}&#34;, (cls,), {&#34;module&#34;: module})
 
     def dyn_str_constructor(self, node: yaml.nodes.ScalarNode) -&gt; str:
-        &#34;&#34;&#34;Responsible for the switching of one or more &#34;[[ DYNAMIC_VAR ]]&#34; strings with the respective attributes value in a give module.
+        &#34;&#34;&#34;Responsible for the switching of one or more &#34;[[ DYNAMIC_VAR ]]&#34; strings with the respective attributes value in a given module.
 
         Args:
             node: Parsed item whose dynamic values that map to the &#34;[[ DYNAMIC_VAR ]]&#34; convention
                 are replaced with the respective attributes in te provided module.
 
         Returns:
-            Constructed `str`
+            Constructed `str` or numerical.
         &#34;&#34;&#34;
         value = node.value
 
@@ -728,22 +777,22 @@ voyage_data_cloud_mapping = input_config.get(source_key="VOYAGE_DATA")
 </ul>
 <h3>Class variables</h3>
 <dl>
-<dt id="dynamicio.config.SafeDynamicLoader.dynamic_data_matcher"><code class="name">var <span class="ident">dynamic_data_matcher</span></code></dt>
+<dt id="dynamicio.config.SafeDynamicResourceLoader.dynamic_data_matcher"><code class="name">var <span class="ident">dynamic_data_matcher</span></code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="dynamicio.config.SafeDynamicLoader.module"><code class="name">var <span class="ident">module</span></code></dt>
+<dt id="dynamicio.config.SafeDynamicResourceLoader.module"><code class="name">var <span class="ident">module</span></code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
-<dt id="dynamicio.config.SafeDynamicLoader.yaml_constructors"><code class="name">var <span class="ident">yaml_constructors</span></code></dt>
+<dt id="dynamicio.config.SafeDynamicResourceLoader.yaml_constructors"><code class="name">var <span class="ident">yaml_constructors</span></code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
 </dl>
 <h3>Static methods</h3>
 <dl>
-<dt id="dynamicio.config.SafeDynamicLoader.with_module"><code class="name flex">
+<dt id="dynamicio.config.SafeDynamicResourceLoader.with_module"><code class="name flex">
 <span>def <span class="ident">with_module</span></span>(<span>module: module)</span>
 </code></dt>
 <dd>
@@ -775,11 +824,11 @@ def with_module(cls, module: ModuleType):
 </dl>
 <h3>Methods</h3>
 <dl>
-<dt id="dynamicio.config.SafeDynamicLoader.dyn_str_constructor"><code class="name flex">
+<dt id="dynamicio.config.SafeDynamicResourceLoader.dyn_str_constructor"><code class="name flex">
 <span>def <span class="ident">dyn_str_constructor</span></span>(<span>self, node: yaml.nodes.ScalarNode) ‑> str</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Responsible for the switching of one or more "[[ DYNAMIC_VAR ]]" strings with the respective attributes value in a give module.</p>
+<div class="desc"><p>Responsible for the switching of one or more "[[ DYNAMIC_VAR ]]" strings with the respective attributes value in a given module.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>node</code></strong></dt>
@@ -787,20 +836,20 @@ def with_module(cls, module: ModuleType):
 are replaced with the respective attributes in te provided module.</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<p>Constructed <code>str</code></p></div>
+<p>Constructed <code>str</code> or numerical.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def dyn_str_constructor(self, node: yaml.nodes.ScalarNode) -&gt; str:
-    &#34;&#34;&#34;Responsible for the switching of one or more &#34;[[ DYNAMIC_VAR ]]&#34; strings with the respective attributes value in a give module.
+    &#34;&#34;&#34;Responsible for the switching of one or more &#34;[[ DYNAMIC_VAR ]]&#34; strings with the respective attributes value in a given module.
 
     Args:
         node: Parsed item whose dynamic values that map to the &#34;[[ DYNAMIC_VAR ]]&#34; convention
             are replaced with the respective attributes in te provided module.
 
     Returns:
-        Constructed `str`
+        Constructed `str` or numerical.
     &#34;&#34;&#34;
     value = node.value
 
@@ -810,6 +859,170 @@ are replaced with the respective attributes in te provided module.</dd>
 
         value = self.dynamic_data_matcher.sub(f&#34;\\g&lt;1&gt;{replacement}\\g&lt;4&gt;&#34;, value)
 
+    return value</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+<dt id="dynamicio.config.SafeDynamicSchemaLoader"><code class="flex name class">
+<span>class <span class="ident">SafeDynamicSchemaLoader</span></span>
+<span>(</span><span>stream)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Implements a dynamic yaml loader that parses yaml files and replaces strings that map to [[ DYNAMIC_VAR ]].</p>
+<p>Dynamic variables defined in a provided module object.</p>
+<p>Initialize the scanner.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class SafeDynamicSchemaLoader(yaml.SafeLoader):
+    &#34;&#34;&#34;Implements a dynamic yaml loader that parses yaml files and replaces strings that map to [[ DYNAMIC_VAR ]].
+
+    Dynamic variables defined in a provided module object.
+    &#34;&#34;&#34;
+
+    module = None
+    dynamic_data_matcher = re.compile(r&#34;(.*)(\[\[\s*(\S+)\s*]])(.*)&#34;)
+
+    @classmethod
+    def with_module(cls, module: ModuleType):
+        &#34;&#34;&#34;Creates a dynamic subclass of SafeDynamicLoader with the `data_module` attribute set to `module`.
+
+        Args:
+            module: A global vars module with all the dynamic values defined in it.
+
+        Returns:
+            type
+        &#34;&#34;&#34;
+        return type(f&#34;{cls.__name__}_{module.__name__}&#34;, (cls,), {&#34;module&#34;: module})
+
+    def dyn_value_constructor(self, node: yaml.nodes.ScalarNode) -&gt; Any:
+        &#34;&#34;&#34;Responsible for the switching of one or more &#34;[[ DYNAMIC_VAR ]]&#34; strings with the respective attributes value in a given module.
+
+        Args:
+            node: Parsed item whose dynamic values that map to the &#34;[[ DYNAMIC_VAR ]]&#34; convention
+                are replaced with the respective attributes in te provided module.
+
+        Returns:
+            Constructed `str` or numerical.
+        &#34;&#34;&#34;
+        value = node.value
+
+        while result := self.dynamic_data_matcher.match(value):
+            ref = result.group(3)
+            replacement = getattr(self.module, ref)
+
+            value = self.dynamic_data_matcher.sub(f&#34;\\g&lt;1&gt;{replacement}\\g&lt;4&gt;&#34;, value)
+
+        try:
+            value = float(value)
+            return value
+        except ValueError:
+            pass
+        return value</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li>yaml.loader.SafeLoader</li>
+<li>yaml.reader.Reader</li>
+<li>yaml.scanner.Scanner</li>
+<li>yaml.parser.Parser</li>
+<li>yaml.composer.Composer</li>
+<li>yaml.constructor.SafeConstructor</li>
+<li>yaml.constructor.BaseConstructor</li>
+<li>yaml.resolver.Resolver</li>
+<li>yaml.resolver.BaseResolver</li>
+</ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="dynamicio.config.SafeDynamicSchemaLoader.dynamic_data_matcher"><code class="name">var <span class="ident">dynamic_data_matcher</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="dynamicio.config.SafeDynamicSchemaLoader.module"><code class="name">var <span class="ident">module</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt id="dynamicio.config.SafeDynamicSchemaLoader.yaml_constructors"><code class="name">var <span class="ident">yaml_constructors</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+<h3>Static methods</h3>
+<dl>
+<dt id="dynamicio.config.SafeDynamicSchemaLoader.with_module"><code class="name flex">
+<span>def <span class="ident">with_module</span></span>(<span>module: module)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Creates a dynamic subclass of SafeDynamicLoader with the <code>data_module</code> attribute set to <code>module</code>.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>module</code></strong></dt>
+<dd>A global vars module with all the dynamic values defined in it.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>type</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@classmethod
+def with_module(cls, module: ModuleType):
+    &#34;&#34;&#34;Creates a dynamic subclass of SafeDynamicLoader with the `data_module` attribute set to `module`.
+
+    Args:
+        module: A global vars module with all the dynamic values defined in it.
+
+    Returns:
+        type
+    &#34;&#34;&#34;
+    return type(f&#34;{cls.__name__}_{module.__name__}&#34;, (cls,), {&#34;module&#34;: module})</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="dynamicio.config.SafeDynamicSchemaLoader.dyn_value_constructor"><code class="name flex">
+<span>def <span class="ident">dyn_value_constructor</span></span>(<span>self, node: yaml.nodes.ScalarNode) ‑> Any</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Responsible for the switching of one or more "[[ DYNAMIC_VAR ]]" strings with the respective attributes value in a given module.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>node</code></strong></dt>
+<dd>Parsed item whose dynamic values that map to the "[[ DYNAMIC_VAR ]]" convention
+are replaced with the respective attributes in te provided module.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>Constructed <code>str</code> or numerical.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def dyn_value_constructor(self, node: yaml.nodes.ScalarNode) -&gt; Any:
+    &#34;&#34;&#34;Responsible for the switching of one or more &#34;[[ DYNAMIC_VAR ]]&#34; strings with the respective attributes value in a given module.
+
+    Args:
+        node: Parsed item whose dynamic values that map to the &#34;[[ DYNAMIC_VAR ]]&#34; convention
+            are replaced with the respective attributes in te provided module.
+
+    Returns:
+        Constructed `str` or numerical.
+    &#34;&#34;&#34;
+    value = node.value
+
+    while result := self.dynamic_data_matcher.match(value):
+        ref = result.group(3)
+        replacement = getattr(self.module, ref)
+
+        value = self.dynamic_data_matcher.sub(f&#34;\\g&lt;1&gt;{replacement}\\g&lt;4&gt;&#34;, value)
+
+    try:
+        value = float(value)
+        return value
+    except ValueError:
+        pass
     return value</code></pre>
 </details>
 </dd>
@@ -840,13 +1053,23 @@ are replaced with the respective attributes in te provided module.</dd>
 </ul>
 </li>
 <li>
-<h4><code><a title="dynamicio.config.SafeDynamicLoader" href="#dynamicio.config.SafeDynamicLoader">SafeDynamicLoader</a></code></h4>
+<h4><code><a title="dynamicio.config.SafeDynamicResourceLoader" href="#dynamicio.config.SafeDynamicResourceLoader">SafeDynamicResourceLoader</a></code></h4>
 <ul class="">
-<li><code><a title="dynamicio.config.SafeDynamicLoader.dyn_str_constructor" href="#dynamicio.config.SafeDynamicLoader.dyn_str_constructor">dyn_str_constructor</a></code></li>
-<li><code><a title="dynamicio.config.SafeDynamicLoader.dynamic_data_matcher" href="#dynamicio.config.SafeDynamicLoader.dynamic_data_matcher">dynamic_data_matcher</a></code></li>
-<li><code><a title="dynamicio.config.SafeDynamicLoader.module" href="#dynamicio.config.SafeDynamicLoader.module">module</a></code></li>
-<li><code><a title="dynamicio.config.SafeDynamicLoader.with_module" href="#dynamicio.config.SafeDynamicLoader.with_module">with_module</a></code></li>
-<li><code><a title="dynamicio.config.SafeDynamicLoader.yaml_constructors" href="#dynamicio.config.SafeDynamicLoader.yaml_constructors">yaml_constructors</a></code></li>
+<li><code><a title="dynamicio.config.SafeDynamicResourceLoader.dyn_str_constructor" href="#dynamicio.config.SafeDynamicResourceLoader.dyn_str_constructor">dyn_str_constructor</a></code></li>
+<li><code><a title="dynamicio.config.SafeDynamicResourceLoader.dynamic_data_matcher" href="#dynamicio.config.SafeDynamicResourceLoader.dynamic_data_matcher">dynamic_data_matcher</a></code></li>
+<li><code><a title="dynamicio.config.SafeDynamicResourceLoader.module" href="#dynamicio.config.SafeDynamicResourceLoader.module">module</a></code></li>
+<li><code><a title="dynamicio.config.SafeDynamicResourceLoader.with_module" href="#dynamicio.config.SafeDynamicResourceLoader.with_module">with_module</a></code></li>
+<li><code><a title="dynamicio.config.SafeDynamicResourceLoader.yaml_constructors" href="#dynamicio.config.SafeDynamicResourceLoader.yaml_constructors">yaml_constructors</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="dynamicio.config.SafeDynamicSchemaLoader" href="#dynamicio.config.SafeDynamicSchemaLoader">SafeDynamicSchemaLoader</a></code></h4>
+<ul class="">
+<li><code><a title="dynamicio.config.SafeDynamicSchemaLoader.dyn_value_constructor" href="#dynamicio.config.SafeDynamicSchemaLoader.dyn_value_constructor">dyn_value_constructor</a></code></li>
+<li><code><a title="dynamicio.config.SafeDynamicSchemaLoader.dynamic_data_matcher" href="#dynamicio.config.SafeDynamicSchemaLoader.dynamic_data_matcher">dynamic_data_matcher</a></code></li>
+<li><code><a title="dynamicio.config.SafeDynamicSchemaLoader.module" href="#dynamicio.config.SafeDynamicSchemaLoader.module">module</a></code></li>
+<li><code><a title="dynamicio.config.SafeDynamicSchemaLoader.with_module" href="#dynamicio.config.SafeDynamicSchemaLoader.with_module">with_module</a></code></li>
+<li><code><a title="dynamicio.config.SafeDynamicSchemaLoader.yaml_constructors" href="#dynamicio.config.SafeDynamicSchemaLoader.yaml_constructors">yaml_constructors</a></code></li>
 </ul>
 </li>
 </ul>

--- a/docs/core.html
+++ b/docs/core.html
@@ -31,26 +31,22 @@
 # pylint: disable=no-member
 __all__ = [&#34;DynamicDataIO&#34;, &#34;SCHEMA_FROM_FILE&#34;]
 
+import asyncio
 import inspect
+import re
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Mapping, MutableMapping, Optional
 
 import pandas as pd  # type: ignore
 from magic_logger import logger
 
 from dynamicio import validations
-from dynamicio.errors import (
-    ADVICE_MSG,
-    CASTING_WARNING_MSG,
-    NOTICE_MSG,
-    ColumnsDataTypeError,
-    CustomValidationError,
-    MissingSchemaDefinition,
-    SchemaNotFoundError,
-    SchemaValidationError,
-)
+from dynamicio.errors import CASTING_WARNING_MSG, NOTICE_MSG, ColumnsDataTypeError, MissingSchemaDefinition, SchemaNotFoundError, SchemaValidationError
 from dynamicio.metrics import get_metric
 
 SCHEMA_FROM_FILE = {&#34;schema&#34;: object()}
+
+pool = ThreadPoolExecutor()
 
 
 class DynamicDataIO:
@@ -102,6 +98,7 @@ class DynamicDataIO:
             raise TypeError(&#34;Abstract class DynamicDataIO cannot be used to instantiate an object...&#34;)
 
         self.sources_config = source_config
+        self.name = self._transform_class_name_to_dataset_name(self.__class__.__name__)
         self.apply_schema_validations = apply_schema_validations
         self.log_schema_metrics = log_schema_metrics
         self.show_casting_warnings = show_casting_warnings
@@ -110,6 +107,7 @@ class DynamicDataIO:
         if self.schema is SCHEMA_FROM_FILE:
             try:
                 self.schema = self.sources_config[&#34;schema&#34;]
+                self.name = self.sources_config[&#34;name&#34;].upper()
                 self.schema_validations = self.sources_config[&#34;validations&#34;]
                 self.schema_metrics = self.sources_config[&#34;metrics&#34;]
             except KeyError as _error:
@@ -131,6 +129,15 @@ class DynamicDataIO:
             if cls.schema is None or (cls.schema is not SCHEMA_FROM_FILE and len(cls.schema) == 0):
                 raise ValueError(f&#34;schema for class {cls} cannot be None or empty...&#34;)
 
+    async def async_read(self):
+        &#34;&#34;&#34;Allows the use of asyncio to concurrently read files in memory.
+
+        Returns:
+            A pandas dataframe or an iterable.
+        &#34;&#34;&#34;
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(pool, self.read)
+
     def read(self) -&gt; pd.DataFrame:
         &#34;&#34;&#34;Reads data source and returns a schema validated dataframe (by means of _apply_schema).
 
@@ -140,9 +147,6 @@ class DynamicDataIO:
         source_name = self.sources_config.get(&#34;type&#34;)
         df = getattr(self, f&#34;_read_from_{source_name}&#34;)()
 
-        if not self.validate(df):
-            raise CustomValidationError(&#34;User-defined validation has failed!&#34;)
-
         df = self._apply_schema(df)
         if self.apply_schema_validations:
             self.validate_from_schema(df)
@@ -151,22 +155,25 @@ class DynamicDataIO:
 
         return df
 
+    async def async_write(self, df: pd.DataFrame):
+        &#34;&#34;&#34;Allows the use of asyncio to concurrently write files out.
+
+        Args:
+            df: The data to be written
+        &#34;&#34;&#34;
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(pool, self.write, df)
+
     def write(self, df: pd.DataFrame):
         &#34;&#34;&#34;Sink data to a given source based on the sources_config.
 
         Args:
             df: The data to be written
-
-        Returns:
-            Nothing
         &#34;&#34;&#34;
         source_name = self.sources_config.get(&#34;type&#34;)
         if set(list(df.columns)) != set(self.schema.keys()):  # pylint: disable=E1101
             columns = [column for column in df.columns.to_list() if column in self.schema.keys()]
             df = df[columns]
-
-        if not self.validate(df):
-            raise CustomValidationError(&#34;User-defined validation has failed!&#34;)
 
         if self.apply_schema_validations:
             self.validate_from_schema(df)
@@ -198,12 +205,7 @@ class DynamicDataIO:
         for column in self.schema_validations.keys():
             for validation in self.schema_validations[column].keys():
                 if self.schema_validations[column][validation][&#34;apply&#34;] is True:
-                    validation_result = getattr(validations, validation)(
-                        self.__class__.__name__,
-                        df,
-                        column,
-                        **self.schema_validations[column][validation][&#34;options&#34;],
-                    )
+                    validation_result = getattr(validations, validation)(self.name, df, column, **self.schema_validations[column][validation][&#34;options&#34;])
                     if not validation_result.valid:
                         failed_validations[validation] = validation_result.message
 
@@ -226,35 +228,9 @@ class DynamicDataIO:
 
         for column in self.schema_metrics.keys():
             for metric in self.schema_metrics[column]:
-                get_metric(metric)(self.__class__.__name__, df, column)()  # type: ignore
+                get_metric(metric)(self.name, df, column)()  # type: ignore
 
         return self
-
-    @staticmethod
-    def validate(df: pd.DataFrame) -&gt; bool:  # pylint: disable=W0613
-        &#34;&#34;&#34;Abstract method used as part of the I/O logic.
-
-        This method should be overriden by the a user defined one, when the user wants to intervene to the I/O logic.
-
-        Example:
-           &gt;&gt;&gt; class Foo(UnifiedIO):
-           &gt;&gt;&gt;    schema = SCHEMA_FROM_FILE
-           &gt;&gt;&gt;
-           &gt;&gt;&gt;    @staticmethod
-           &gt;&gt;&gt;    def validate(df: pd.DataFrame):
-           &gt;&gt;&gt;       return df[&#34;col_a&#34;].isna().sum() == 0
-           &gt;&gt;&gt;
-           &gt;&gt;&gt;
-           &gt;&gt;&gt;
-           &gt;&gt;&gt;  df = Foo(source_config=input_config.get(source_key=&#34;FOO&#34;)).read())
-           &gt;&gt;&gt;
-        Args:
-            df: A pandas dataframe.
-
-        Returns:
-            True if validations pass and false otherwise.
-        &#34;&#34;&#34;
-        return True
 
     def _apply_schema(self, df: pd.DataFrame) -&gt; pd.DataFrame:
         &#34;&#34;&#34;Called by the `self.read()` and the `self._write_to_local()` methods.
@@ -275,6 +251,16 @@ class DynamicDataIO:
             raise ColumnsDataTypeError()
         return df
 
+    @staticmethod
+    def _transform_class_name_to_dataset_name(string_to_transform: str) -&gt; str:
+        &#34;&#34;&#34;Called by the init function to fetch dataset names from class name.
+
+        Used to create dataset name from class name, turns camel case into upper snake case.
+        For example: &#39;ThisNameABC&#39; -&gt; &#39;THIS_NAME_ABC&#39;.
+        &#34;&#34;&#34;
+        words = re.findall(r&#34;\d[A-Z]+|[A-Z]?[a-z\d]+|[A-Z]{2,}(?=[A-Z][a-z]|\d|\W|$)|\d+|[A-Z]{2,}|[A-Z]&#34;, string_to_transform)
+        return &#34;_&#34;.join(map(str.lower, words)).upper()
+
     def _has_valid_dtypes(self, df: pd.DataFrame) -&gt; bool:
         &#34;&#34;&#34;Checks if `df` has the expected dtypes defined in `schema`.
 
@@ -292,23 +278,19 @@ class DynamicDataIO:
             bool - `True` if `df` has the given dtypes, `False` otherwise
         &#34;&#34;&#34;
         dtypes = df.dtypes
-        print(&#34;dtypes: &#34;, dtypes)
-        print(&#34;\ndf:&#34;, df)
 
         for column_name, expected_dtype in self.schema.items():
-            print(f&#34;\n{column_name} ---- {expected_dtype}&#34;)
             found_dtype = dtypes[column_name].name
             if found_dtype != expected_dtype:
                 if self.show_casting_warnings:
-                    logger.info(f&#34;Expected: &#39;{expected_dtype}&#39; dtype for {self.__class__.__name__}[&#39;{column_name}]&#39;, found &#39;{found_dtype}&#39;&#34;)
+                    logger.info(f&#34;Expected: &#39;{expected_dtype}&#39; dtype for {self.name}[&#39;{column_name}]&#39;, found &#39;{found_dtype}&#39;&#34;)
                 try:
                     if len(set([type(v) for v in df[column_name].values])) &gt; 1:  # pylint: disable=consider-using-set-comprehension
                         logger.warning(CASTING_WARNING_MSG.format(column_name, expected_dtype, found_dtype))  # pylint: disable=logging-format-interpolation
                         logger.info(NOTICE_MSG.format(column_name))  # pylint: disable=logging-format-interpolation
-                        logger.info(ADVICE_MSG)
                     df.loc[:, column_name] = df[column_name].astype(self.schema[column_name])
                 except (ValueError, TypeError):
-                    logger.error(f&#34;ValueError: Tried casting column {self.__class__.__name__}[&#39;{column_name}]&#39; to &#39;{expected_dtype}&#39; &#34; f&#34;from &#39;{found_dtype}&#39;, but failed&#34;)
+                    logger.error(f&#34;ValueError: Tried casting column {self.name}[&#39;{column_name}]&#39; to &#39;{expected_dtype}&#39; &#34; f&#34;from &#39;{found_dtype}&#39;, but failed&#34;)
                     return False
         return True
 
@@ -435,6 +417,7 @@ class DynamicDataIO:
             raise TypeError(&#34;Abstract class DynamicDataIO cannot be used to instantiate an object...&#34;)
 
         self.sources_config = source_config
+        self.name = self._transform_class_name_to_dataset_name(self.__class__.__name__)
         self.apply_schema_validations = apply_schema_validations
         self.log_schema_metrics = log_schema_metrics
         self.show_casting_warnings = show_casting_warnings
@@ -443,6 +426,7 @@ class DynamicDataIO:
         if self.schema is SCHEMA_FROM_FILE:
             try:
                 self.schema = self.sources_config[&#34;schema&#34;]
+                self.name = self.sources_config[&#34;name&#34;].upper()
                 self.schema_validations = self.sources_config[&#34;validations&#34;]
                 self.schema_metrics = self.sources_config[&#34;metrics&#34;]
             except KeyError as _error:
@@ -464,6 +448,15 @@ class DynamicDataIO:
             if cls.schema is None or (cls.schema is not SCHEMA_FROM_FILE and len(cls.schema) == 0):
                 raise ValueError(f&#34;schema for class {cls} cannot be None or empty...&#34;)
 
+    async def async_read(self):
+        &#34;&#34;&#34;Allows the use of asyncio to concurrently read files in memory.
+
+        Returns:
+            A pandas dataframe or an iterable.
+        &#34;&#34;&#34;
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(pool, self.read)
+
     def read(self) -&gt; pd.DataFrame:
         &#34;&#34;&#34;Reads data source and returns a schema validated dataframe (by means of _apply_schema).
 
@@ -473,9 +466,6 @@ class DynamicDataIO:
         source_name = self.sources_config.get(&#34;type&#34;)
         df = getattr(self, f&#34;_read_from_{source_name}&#34;)()
 
-        if not self.validate(df):
-            raise CustomValidationError(&#34;User-defined validation has failed!&#34;)
-
         df = self._apply_schema(df)
         if self.apply_schema_validations:
             self.validate_from_schema(df)
@@ -484,22 +474,25 @@ class DynamicDataIO:
 
         return df
 
+    async def async_write(self, df: pd.DataFrame):
+        &#34;&#34;&#34;Allows the use of asyncio to concurrently write files out.
+
+        Args:
+            df: The data to be written
+        &#34;&#34;&#34;
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(pool, self.write, df)
+
     def write(self, df: pd.DataFrame):
         &#34;&#34;&#34;Sink data to a given source based on the sources_config.
 
         Args:
             df: The data to be written
-
-        Returns:
-            Nothing
         &#34;&#34;&#34;
         source_name = self.sources_config.get(&#34;type&#34;)
         if set(list(df.columns)) != set(self.schema.keys()):  # pylint: disable=E1101
             columns = [column for column in df.columns.to_list() if column in self.schema.keys()]
             df = df[columns]
-
-        if not self.validate(df):
-            raise CustomValidationError(&#34;User-defined validation has failed!&#34;)
 
         if self.apply_schema_validations:
             self.validate_from_schema(df)
@@ -531,12 +524,7 @@ class DynamicDataIO:
         for column in self.schema_validations.keys():
             for validation in self.schema_validations[column].keys():
                 if self.schema_validations[column][validation][&#34;apply&#34;] is True:
-                    validation_result = getattr(validations, validation)(
-                        self.__class__.__name__,
-                        df,
-                        column,
-                        **self.schema_validations[column][validation][&#34;options&#34;],
-                    )
+                    validation_result = getattr(validations, validation)(self.name, df, column, **self.schema_validations[column][validation][&#34;options&#34;])
                     if not validation_result.valid:
                         failed_validations[validation] = validation_result.message
 
@@ -559,35 +547,9 @@ class DynamicDataIO:
 
         for column in self.schema_metrics.keys():
             for metric in self.schema_metrics[column]:
-                get_metric(metric)(self.__class__.__name__, df, column)()  # type: ignore
+                get_metric(metric)(self.name, df, column)()  # type: ignore
 
         return self
-
-    @staticmethod
-    def validate(df: pd.DataFrame) -&gt; bool:  # pylint: disable=W0613
-        &#34;&#34;&#34;Abstract method used as part of the I/O logic.
-
-        This method should be overriden by the a user defined one, when the user wants to intervene to the I/O logic.
-
-        Example:
-           &gt;&gt;&gt; class Foo(UnifiedIO):
-           &gt;&gt;&gt;    schema = SCHEMA_FROM_FILE
-           &gt;&gt;&gt;
-           &gt;&gt;&gt;    @staticmethod
-           &gt;&gt;&gt;    def validate(df: pd.DataFrame):
-           &gt;&gt;&gt;       return df[&#34;col_a&#34;].isna().sum() == 0
-           &gt;&gt;&gt;
-           &gt;&gt;&gt;
-           &gt;&gt;&gt;
-           &gt;&gt;&gt;  df = Foo(source_config=input_config.get(source_key=&#34;FOO&#34;)).read())
-           &gt;&gt;&gt;
-        Args:
-            df: A pandas dataframe.
-
-        Returns:
-            True if validations pass and false otherwise.
-        &#34;&#34;&#34;
-        return True
 
     def _apply_schema(self, df: pd.DataFrame) -&gt; pd.DataFrame:
         &#34;&#34;&#34;Called by the `self.read()` and the `self._write_to_local()` methods.
@@ -608,6 +570,16 @@ class DynamicDataIO:
             raise ColumnsDataTypeError()
         return df
 
+    @staticmethod
+    def _transform_class_name_to_dataset_name(string_to_transform: str) -&gt; str:
+        &#34;&#34;&#34;Called by the init function to fetch dataset names from class name.
+
+        Used to create dataset name from class name, turns camel case into upper snake case.
+        For example: &#39;ThisNameABC&#39; -&gt; &#39;THIS_NAME_ABC&#39;.
+        &#34;&#34;&#34;
+        words = re.findall(r&#34;\d[A-Z]+|[A-Z]?[a-z\d]+|[A-Z]{2,}(?=[A-Z][a-z]|\d|\W|$)|\d+|[A-Z]{2,}|[A-Z]&#34;, string_to_transform)
+        return &#34;_&#34;.join(map(str.lower, words)).upper()
+
     def _has_valid_dtypes(self, df: pd.DataFrame) -&gt; bool:
         &#34;&#34;&#34;Checks if `df` has the expected dtypes defined in `schema`.
 
@@ -625,23 +597,19 @@ class DynamicDataIO:
             bool - `True` if `df` has the given dtypes, `False` otherwise
         &#34;&#34;&#34;
         dtypes = df.dtypes
-        print(&#34;dtypes: &#34;, dtypes)
-        print(&#34;\ndf:&#34;, df)
 
         for column_name, expected_dtype in self.schema.items():
-            print(f&#34;\n{column_name} ---- {expected_dtype}&#34;)
             found_dtype = dtypes[column_name].name
             if found_dtype != expected_dtype:
                 if self.show_casting_warnings:
-                    logger.info(f&#34;Expected: &#39;{expected_dtype}&#39; dtype for {self.__class__.__name__}[&#39;{column_name}]&#39;, found &#39;{found_dtype}&#39;&#34;)
+                    logger.info(f&#34;Expected: &#39;{expected_dtype}&#39; dtype for {self.name}[&#39;{column_name}]&#39;, found &#39;{found_dtype}&#39;&#34;)
                 try:
                     if len(set([type(v) for v in df[column_name].values])) &gt; 1:  # pylint: disable=consider-using-set-comprehension
                         logger.warning(CASTING_WARNING_MSG.format(column_name, expected_dtype, found_dtype))  # pylint: disable=logging-format-interpolation
                         logger.info(NOTICE_MSG.format(column_name))  # pylint: disable=logging-format-interpolation
-                        logger.info(ADVICE_MSG)
                     df.loc[:, column_name] = df[column_name].astype(self.schema[column_name])
                 except (ValueError, TypeError):
-                    logger.error(f&#34;ValueError: Tried casting column {self.__class__.__name__}[&#39;{column_name}]&#39; to &#39;{expected_dtype}&#39; &#34; f&#34;from &#39;{found_dtype}&#39;, but failed&#34;)
+                    logger.error(f&#34;ValueError: Tried casting column {self.name}[&#39;{column_name}]&#39; to &#39;{expected_dtype}&#39; &#34; f&#34;from &#39;{found_dtype}&#39;, but failed&#34;)
                     return False
         return True
 
@@ -674,68 +642,53 @@ class DynamicDataIO:
 <div class="desc"></div>
 </dd>
 </dl>
-<h3>Static methods</h3>
+<h3>Methods</h3>
 <dl>
-<dt id="dynamicio.core.DynamicDataIO.validate"><code class="name flex">
-<span>def <span class="ident">validate</span></span>(<span>df: pandas.core.frame.DataFrame) ‑> bool</span>
+<dt id="dynamicio.core.DynamicDataIO.async_read"><code class="name flex">
+<span>async def <span class="ident">async_read</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Abstract method used as part of the I/O logic.</p>
-<p>This method should be overriden by the a user defined one, when the user wants to intervene to the I/O logic.</p>
-<h2 id="example">Example</h2>
-<pre><code class="language-python-repl">&gt;&gt;&gt; class Foo(UnifiedIO):
-&gt;&gt;&gt;    schema = SCHEMA_FROM_FILE
-&gt;&gt;&gt;
-&gt;&gt;&gt;    @staticmethod
-&gt;&gt;&gt;    def validate(df: pd.DataFrame):
-&gt;&gt;&gt;       return df[&quot;col_a&quot;].isna().sum() == 0
-&gt;&gt;&gt;
-&gt;&gt;&gt;
-&gt;&gt;&gt;
-&gt;&gt;&gt;  df = Foo(source_config=input_config.get(source_key=&quot;FOO&quot;)).read())
-&gt;&gt;&gt;
-</code></pre>
-<h2 id="args">Args</h2>
-<dl>
-<dt><strong><code>df</code></strong></dt>
-<dd>A pandas dataframe.</dd>
-</dl>
+<div class="desc"><p>Allows the use of asyncio to concurrently read files in memory.</p>
 <h2 id="returns">Returns</h2>
-<p>True if validations pass and false otherwise.</p></div>
+<p>A pandas dataframe or an iterable.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">@staticmethod
-def validate(df: pd.DataFrame) -&gt; bool:  # pylint: disable=W0613
-    &#34;&#34;&#34;Abstract method used as part of the I/O logic.
-
-    This method should be overriden by the a user defined one, when the user wants to intervene to the I/O logic.
-
-    Example:
-       &gt;&gt;&gt; class Foo(UnifiedIO):
-       &gt;&gt;&gt;    schema = SCHEMA_FROM_FILE
-       &gt;&gt;&gt;
-       &gt;&gt;&gt;    @staticmethod
-       &gt;&gt;&gt;    def validate(df: pd.DataFrame):
-       &gt;&gt;&gt;       return df[&#34;col_a&#34;].isna().sum() == 0
-       &gt;&gt;&gt;
-       &gt;&gt;&gt;
-       &gt;&gt;&gt;
-       &gt;&gt;&gt;  df = Foo(source_config=input_config.get(source_key=&#34;FOO&#34;)).read())
-       &gt;&gt;&gt;
-    Args:
-        df: A pandas dataframe.
+<pre><code class="python">async def async_read(self):
+    &#34;&#34;&#34;Allows the use of asyncio to concurrently read files in memory.
 
     Returns:
-        True if validations pass and false otherwise.
+        A pandas dataframe or an iterable.
     &#34;&#34;&#34;
-    return True</code></pre>
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(pool, self.read)</code></pre>
 </details>
 </dd>
-</dl>
-<h3>Methods</h3>
+<dt id="dynamicio.core.DynamicDataIO.async_write"><code class="name flex">
+<span>async def <span class="ident">async_write</span></span>(<span>self, df: pandas.core.frame.DataFrame)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Allows the use of asyncio to concurrently write files out.</p>
+<h2 id="args">Args</h2>
 <dl>
+<dt><strong><code>df</code></strong></dt>
+<dd>The data to be written</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def async_write(self, df: pd.DataFrame):
+    &#34;&#34;&#34;Allows the use of asyncio to concurrently write files out.
+
+    Args:
+        df: The data to be written
+    &#34;&#34;&#34;
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(pool, self.write, df)</code></pre>
+</details>
+</dd>
 <dt id="dynamicio.core.DynamicDataIO.log_metrics_from_schema"><code class="name flex">
 <span>def <span class="ident">log_metrics_from_schema</span></span>(<span>self, df: pandas.core.frame.DataFrame) ‑> <a title="dynamicio.core.DynamicDataIO" href="#dynamicio.core.DynamicDataIO">DynamicDataIO</a></span>
 </code></dt>
@@ -766,7 +719,7 @@ def validate(df: pd.DataFrame) -&gt; bool:  # pylint: disable=W0613
 
     for column in self.schema_metrics.keys():
         for metric in self.schema_metrics[column]:
-            get_metric(metric)(self.__class__.__name__, df, column)()  # type: ignore
+            get_metric(metric)(self.name, df, column)()  # type: ignore
 
     return self</code></pre>
 </details>
@@ -790,9 +743,6 @@ def validate(df: pd.DataFrame) -&gt; bool:  # pylint: disable=W0613
     &#34;&#34;&#34;
     source_name = self.sources_config.get(&#34;type&#34;)
     df = getattr(self, f&#34;_read_from_{source_name}&#34;)()
-
-    if not self.validate(df):
-        raise CustomValidationError(&#34;User-defined validation has failed!&#34;)
 
     df = self._apply_schema(df)
     if self.apply_schema_validations:
@@ -847,12 +797,7 @@ validation that failed.</dd>
     for column in self.schema_validations.keys():
         for validation in self.schema_validations[column].keys():
             if self.schema_validations[column][validation][&#34;apply&#34;] is True:
-                validation_result = getattr(validations, validation)(
-                    self.__class__.__name__,
-                    df,
-                    column,
-                    **self.schema_validations[column][validation][&#34;options&#34;],
-                )
+                validation_result = getattr(validations, validation)(self.name, df, column, **self.schema_validations[column][validation][&#34;options&#34;])
                 if not validation_result.valid:
                     failed_validations[validation] = validation_result.message
 
@@ -871,9 +816,7 @@ validation that failed.</dd>
 <dl>
 <dt><strong><code>df</code></strong></dt>
 <dd>The data to be written</dd>
-</dl>
-<h2 id="returns">Returns</h2>
-<p>Nothing</p></div>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -883,17 +826,11 @@ validation that failed.</dd>
 
     Args:
         df: The data to be written
-
-    Returns:
-        Nothing
     &#34;&#34;&#34;
     source_name = self.sources_config.get(&#34;type&#34;)
     if set(list(df.columns)) != set(self.schema.keys()):  # pylint: disable=E1101
         columns = [column for column in df.columns.to_list() if column in self.schema.keys()]
         df = df[columns]
-
-    if not self.validate(df):
-        raise CustomValidationError(&#34;User-defined validation has failed!&#34;)
 
     if self.apply_schema_validations:
         self.validate_from_schema(df)
@@ -924,10 +861,11 @@ validation that failed.</dd>
 <li>
 <h4><code><a title="dynamicio.core.DynamicDataIO" href="#dynamicio.core.DynamicDataIO">DynamicDataIO</a></code></h4>
 <ul class="">
+<li><code><a title="dynamicio.core.DynamicDataIO.async_read" href="#dynamicio.core.DynamicDataIO.async_read">async_read</a></code></li>
+<li><code><a title="dynamicio.core.DynamicDataIO.async_write" href="#dynamicio.core.DynamicDataIO.async_write">async_write</a></code></li>
 <li><code><a title="dynamicio.core.DynamicDataIO.log_metrics_from_schema" href="#dynamicio.core.DynamicDataIO.log_metrics_from_schema">log_metrics_from_schema</a></code></li>
 <li><code><a title="dynamicio.core.DynamicDataIO.read" href="#dynamicio.core.DynamicDataIO.read">read</a></code></li>
 <li><code><a title="dynamicio.core.DynamicDataIO.schema" href="#dynamicio.core.DynamicDataIO.schema">schema</a></code></li>
-<li><code><a title="dynamicio.core.DynamicDataIO.validate" href="#dynamicio.core.DynamicDataIO.validate">validate</a></code></li>
 <li><code><a title="dynamicio.core.DynamicDataIO.validate_from_schema" href="#dynamicio.core.DynamicDataIO.validate_from_schema">validate_from_schema</a></code></li>
 <li><code><a title="dynamicio.core.DynamicDataIO.write" href="#dynamicio.core.DynamicDataIO.write">write</a></code></li>
 </ul>

--- a/docs/errors.html
+++ b/docs/errors.html
@@ -39,9 +39,7 @@ __all__ = [
     &#34;MissingSchemaDefinition&#34;,
     &#34;SchemaNotFoundError&#34;,
     &#34;SchemaValidationError&#34;,
-    &#34;CustomValidationError&#34;,
     &#34;InvalidDatasetTypeError&#34;,
-    &#34;ADVICE_MSG&#34;,
     &#34;CASTING_WARNING_MSG&#34;,
     &#34;NOTICE_MSG&#34;,
 ]
@@ -88,10 +86,6 @@ class SchemaValidationError(DynamicIOError):
     &#34;&#34;&#34;Error raised when schema validation fails.&#34;&#34;&#34;
 
 
-class CustomValidationError(DynamicIOError):
-    &#34;&#34;&#34;Error raised when user-defined validation fails.&#34;&#34;&#34;
-
-
 class MissingSchemaDefinition(DynamicIOError):
     &#34;&#34;&#34;Error raised when schema is not specified in the provided source.&#34;&#34;&#34;
 
@@ -128,8 +122,7 @@ class InvalidDatasetTypeError(DynamicIOError):
 
 # Warning messages
 CASTING_WARNING_MSG = &#34;Applying casting column: &#39;{0}&#39; to: &#39;type:{1}&#39; from &#39;type:{2}&#39; though not advised, as `dtypes`&gt;1 for {0}, which may lead to data corruption!&#34;
-NOTICE_MSG = &#34;Keeping the {0} as is, may anyway cause I/O errors or data corruption issues especially when using `pandas.DataFrame.to_parquet` or `pandas.DataFrame.to_json`.&#34;
-ADVICE_MSG = &#34;Use the `dynamicio.core.DynamicDataIO.validate()` through your `dynamicio.UnifiedIO` instance to apply custom validations as part of this I/O operation.&#34;</code></pre>
+NOTICE_MSG = &#34;Keeping the {0} as is, may anyway cause I/O errors or data corruption issues especially when using `pandas.DataFrame.to_parquet` or `pandas.DataFrame.to_json`.&#34;</code></pre>
 </details>
 </section>
 <section>
@@ -167,45 +160,6 @@ ADVICE_MSG = &#34;Use the `dynamicio.core.DynamicDataIO.validate()` through your
 <div class="desc"></div>
 </dd>
 <dt id="dynamicio.errors.ColumnsDataTypeError.ERROR_STR_DETAILED"><code class="name">var <span class="ident">ERROR_STR_DETAILED</span> : str</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
-</dl>
-<h3>Inherited members</h3>
-<ul class="hlist">
-<li><code><b><a title="dynamicio.errors.DynamicIOError" href="#dynamicio.errors.DynamicIOError">DynamicIOError</a></b></code>:
-<ul class="hlist">
-<li><code><a title="dynamicio.errors.DynamicIOError.message" href="#dynamicio.errors.DynamicIOError.message">message</a></code></li>
-</ul>
-</li>
-</ul>
-</dd>
-<dt id="dynamicio.errors.CustomValidationError"><code class="flex name class">
-<span>class <span class="ident">CustomValidationError</span></span>
-<span>(</span><span>*args, **kwargs)</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Error raised when user-defined validation fails.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">class CustomValidationError(DynamicIOError):
-    &#34;&#34;&#34;Error raised when user-defined validation fails.&#34;&#34;&#34;</code></pre>
-</details>
-<h3>Ancestors</h3>
-<ul class="hlist">
-<li><a title="dynamicio.errors.DynamicIOError" href="#dynamicio.errors.DynamicIOError">DynamicIOError</a></li>
-<li>builtins.Exception</li>
-<li>builtins.BaseException</li>
-</ul>
-<h3>Class variables</h3>
-<dl>
-<dt id="dynamicio.errors.CustomValidationError.ERROR_STR"><code class="name">var <span class="ident">ERROR_STR</span> : str</code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
-<dt id="dynamicio.errors.CustomValidationError.ERROR_STR_DETAILED"><code class="name">var <span class="ident">ERROR_STR_DETAILED</span> : str</code></dt>
 <dd>
 <div class="desc"></div>
 </dd>
@@ -303,7 +257,6 @@ ADVICE_MSG = &#34;Use the `dynamicio.core.DynamicDataIO.validate()` through your
 <h3>Subclasses</h3>
 <ul class="hlist">
 <li><a title="dynamicio.errors.ColumnsDataTypeError" href="#dynamicio.errors.ColumnsDataTypeError">ColumnsDataTypeError</a></li>
-<li><a title="dynamicio.errors.CustomValidationError" href="#dynamicio.errors.CustomValidationError">CustomValidationError</a></li>
 <li><a title="dynamicio.errors.DataSourceError" href="#dynamicio.errors.DataSourceError">DataSourceError</a></li>
 <li><a title="dynamicio.errors.InvalidDatasetTypeError" href="#dynamicio.errors.InvalidDatasetTypeError">InvalidDatasetTypeError</a></li>
 <li><a title="dynamicio.errors.MissingSchemaDefinition" href="#dynamicio.errors.MissingSchemaDefinition">MissingSchemaDefinition</a></li>
@@ -653,13 +606,6 @@ def message(self) -&gt; Optional[Any]:
 <ul class="">
 <li><code><a title="dynamicio.errors.ColumnsDataTypeError.ERROR_STR" href="#dynamicio.errors.ColumnsDataTypeError.ERROR_STR">ERROR_STR</a></code></li>
 <li><code><a title="dynamicio.errors.ColumnsDataTypeError.ERROR_STR_DETAILED" href="#dynamicio.errors.ColumnsDataTypeError.ERROR_STR_DETAILED">ERROR_STR_DETAILED</a></code></li>
-</ul>
-</li>
-<li>
-<h4><code><a title="dynamicio.errors.CustomValidationError" href="#dynamicio.errors.CustomValidationError">CustomValidationError</a></code></h4>
-<ul class="">
-<li><code><a title="dynamicio.errors.CustomValidationError.ERROR_STR" href="#dynamicio.errors.CustomValidationError.ERROR_STR">ERROR_STR</a></code></li>
-<li><code><a title="dynamicio.errors.CustomValidationError.ERROR_STR_DETAILED" href="#dynamicio.errors.CustomValidationError.ERROR_STR_DETAILED">ERROR_STR_DETAILED</a></code></li>
 </ul>
 </li>
 <li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -178,9 +178,10 @@ logger.dict_config(logging_config)</code></pre>
 <ul class="hlist">
 <li><code><b><a title="dynamicio.core.DynamicDataIO" href="core.html#dynamicio.core.DynamicDataIO">DynamicDataIO</a></b></code>:
 <ul class="hlist">
+<li><code><a title="dynamicio.core.DynamicDataIO.async_read" href="core.html#dynamicio.core.DynamicDataIO.async_read">async_read</a></code></li>
+<li><code><a title="dynamicio.core.DynamicDataIO.async_write" href="core.html#dynamicio.core.DynamicDataIO.async_write">async_write</a></code></li>
 <li><code><a title="dynamicio.core.DynamicDataIO.log_metrics_from_schema" href="core.html#dynamicio.core.DynamicDataIO.log_metrics_from_schema">log_metrics_from_schema</a></code></li>
 <li><code><a title="dynamicio.core.DynamicDataIO.read" href="core.html#dynamicio.core.DynamicDataIO.read">read</a></code></li>
-<li><code><a title="dynamicio.core.DynamicDataIO.validate" href="core.html#dynamicio.core.DynamicDataIO.validate">validate</a></code></li>
 <li><code><a title="dynamicio.core.DynamicDataIO.validate_from_schema" href="core.html#dynamicio.core.DynamicDataIO.validate_from_schema">validate_from_schema</a></code></li>
 <li><code><a title="dynamicio.core.DynamicDataIO.write" href="core.html#dynamicio.core.DynamicDataIO.write">write</a></code></li>
 </ul>

--- a/docs/mixins.html
+++ b/docs/mixins.html
@@ -48,6 +48,7 @@ import string
 import tempfile
 from contextlib import contextmanager
 from functools import wraps
+from threading import Lock
 from types import FunctionType
 from typing import Any, Callable, Collection, Dict, Generator, Iterable, Mapping, MutableMapping, Optional, Union
 
@@ -80,6 +81,8 @@ _type_lookup = {
     &#34;datetime64[ns]&#34;: DateTime,
     &#34;bigint&#34;: BigInteger,
 }
+
+hdf_lock = Lock()
 
 
 @contextmanager
@@ -304,6 +307,10 @@ class WithLocal:
 
         All `options` are passed directly to `pd.read_hdf`.
 
+        Caveats: As HDFs are not thread-safe, we use a Lock on this operation. This, practically means
+            that when used with asyncio through `async_read()` HDF files will be read sequentially.
+            For more information see: https://pandas.pydata.org/pandas-docs/dev/user_guide/io.html#caveats
+
         Args:
             file_path: The path to the hdf file to be read.
             options: The pandas `read_hdf` options.
@@ -311,7 +318,9 @@ class WithLocal:
         Returns:
             DataFrame: The dataframe read from the hdf file.
         &#34;&#34;&#34;
-        df = pd.read_hdf(file_path, **options)
+        with hdf_lock:
+            df = pd.read_hdf(file_path, **options)
+
         columns = [column for column in df.columns.to_list() if column in schema.keys()]
         df = df[columns]
         return df
@@ -388,6 +397,10 @@ class WithLocal:
 
         All `options` are passed directly to `df.to_hdf`.
 
+        Caveats: As HDFs are not thread-safe, we use a Lock on this operation. This, practically means
+            that when used with asyncio through `async_read()` HDF files will be written sequentially.
+            For more information see: https://pandas.pydata.org/pandas-docs/dev/user_guide/io.html#caveats
+
         Args:
             df: A dataframe write out.
             file_path: The location where the file needs to be written.
@@ -396,7 +409,7 @@ class WithLocal:
                 - The pandas `to_hdf` options, &amp;;
                 - protocol: The pickle protocol to use for writing the hdf file out; a value &lt;=5.
         &#34;&#34;&#34;
-        with pickle_protocol(protocol=options.pop(&#34;protocol&#34;, None)):
+        with pickle_protocol(protocol=options.pop(&#34;protocol&#34;, None)), hdf_lock:
             df.to_hdf(file_path, key=&#34;df&#34;, mode=&#34;w&#34;, **options)
 
     @staticmethod
@@ -1425,6 +1438,10 @@ Kafka topic.</p>
 
         All `options` are passed directly to `pd.read_hdf`.
 
+        Caveats: As HDFs are not thread-safe, we use a Lock on this operation. This, practically means
+            that when used with asyncio through `async_read()` HDF files will be read sequentially.
+            For more information see: https://pandas.pydata.org/pandas-docs/dev/user_guide/io.html#caveats
+
         Args:
             file_path: The path to the hdf file to be read.
             options: The pandas `read_hdf` options.
@@ -1432,7 +1449,9 @@ Kafka topic.</p>
         Returns:
             DataFrame: The dataframe read from the hdf file.
         &#34;&#34;&#34;
-        df = pd.read_hdf(file_path, **options)
+        with hdf_lock:
+            df = pd.read_hdf(file_path, **options)
+
         columns = [column for column in df.columns.to_list() if column in schema.keys()]
         df = df[columns]
         return df
@@ -1509,6 +1528,10 @@ Kafka topic.</p>
 
         All `options` are passed directly to `df.to_hdf`.
 
+        Caveats: As HDFs are not thread-safe, we use a Lock on this operation. This, practically means
+            that when used with asyncio through `async_read()` HDF files will be written sequentially.
+            For more information see: https://pandas.pydata.org/pandas-docs/dev/user_guide/io.html#caveats
+
         Args:
             df: A dataframe write out.
             file_path: The location where the file needs to be written.
@@ -1517,7 +1540,7 @@ Kafka topic.</p>
                 - The pandas `to_hdf` options, &amp;;
                 - protocol: The pickle protocol to use for writing the hdf file out; a value &lt;=5.
         &#34;&#34;&#34;
-        with pickle_protocol(protocol=options.pop(&#34;protocol&#34;, None)):
+        with pickle_protocol(protocol=options.pop(&#34;protocol&#34;, None)), hdf_lock:
             df.to_hdf(file_path, key=&#34;df&#34;, mode=&#34;w&#34;, **options)
 
     @staticmethod

--- a/docs/validations.html
+++ b/docs/validations.html
@@ -32,7 +32,7 @@ __all__ = [
     &#34;has_unique_values&#34;,
     &#34;has_no_null_values&#34;,
     &#34;has_acceptable_percentage_of_nulls&#34;,
-    &#34;has_acceptable_categorical_values&#34;,
+    &#34;is_in&#34;,
     &#34;is_greater_than&#34;,
     &#34;is_greater_than_or_equal&#34;,
     &#34;is_lower_than&#34;,
@@ -133,7 +133,7 @@ def has_acceptable_percentage_of_nulls(
     )
 
 
-def has_acceptable_categorical_values(dataset: str, df: pd.DataFrame, column: str, categorical_values: Set[str]) -&gt; ValidationResult:
+def is_in(dataset: str, df: pd.DataFrame, column: str, categorical_values: Set[str], match_all: bool = True) -&gt; ValidationResult:
     &#34;&#34;&#34;Checks if the column only has allowed categorical values as per the set provided.
 
     Note:
@@ -144,19 +144,43 @@ def has_acceptable_categorical_values(dataset: str, df: pd.DataFrame, column: st
         df: A DataFrame
         column: The DataFrame column to be validated
         categorical_values: The allowed set of categorical values
+        match_all: If True, the categorical values must be a subset of the allowed set, otherwise they must be equal
 
     Returns:
         An instance of ValidationResult where `Validation.Result.valid` is a bool indicate the success of the validation,
         `Validation.Result.message` is a message (usually used in exceptions), and `Validation.Result.value` is no_of_not_acceptable
     &#34;&#34;&#34;
     unique_values = set(df[column][df[column].notna()].unique())
-    if unique_values.issubset(categorical_values):
-        return ValidationResult(valid=True, message=f&#34;Categorical values for {dataset}[{column}] are acceptable&#34;, value=0)
 
-    count_invalid = (~df[column].isin(categorical_values)).sum()
+    if match_all:
+        return _validate_categoricals_are_a_subset_of_the_acceptable(categorical_values, unique_values, column, dataset, df)
+    return _validate_all_acceptable_categoricals_are_present(categorical_values, unique_values, column, dataset, df)
+
+
+def _validate_all_acceptable_categoricals_are_present(acceptable_categoricals: Set[str], unique_values: Set[str], column: str, dataset: str, df: pd.DataFrame) -&gt; ValidationResult:
+    if unique_values == acceptable_categoricals:
+        return ValidationResult(valid=True, message=f&#34;All acceptable categorical values for {dataset}[{column}] are present&#34;, value=0)
+    if unique_values &lt; acceptable_categoricals:
+        return ValidationResult(
+            valid=False,
+            message=f&#34;Missing categorical values for {dataset}[{column}]: {acceptable_categoricals - unique_values}&#34;,
+            value=len(acceptable_categoricals - unique_values),
+        )
+    count_invalid = (~df[column].isin(acceptable_categoricals)).sum()
     return ValidationResult(
         valid=False,
-        message=f&#34;Values {unique_values - set(categorical_values)} for {dataset}[{column}] are not acceptable for {count_invalid} cells&#34;,
+        message=f&#34;Values {unique_values - set(acceptable_categoricals)} for {dataset}[{column}] are not acceptable for {count_invalid} cells&#34;,
+        value=count_invalid,
+    )
+
+
+def _validate_categoricals_are_a_subset_of_the_acceptable(acceptable_categoricals: Set[str], unique_values: Set[str], column: str, dataset: str, df: pd.DataFrame) -&gt; ValidationResult:
+    if unique_values.issubset(acceptable_categoricals):
+        return ValidationResult(valid=True, message=f&#34;Categorical values for {dataset}[{column}] are acceptable&#34;, value=0)
+    count_invalid = (~df[column].isin(acceptable_categoricals)).sum()
+    return ValidationResult(
+        valid=False,
+        message=f&#34;Values {unique_values - set(acceptable_categoricals)} for {dataset}[{column}] are not acceptable for {count_invalid} cells&#34;,
         value=count_invalid,
     )
 
@@ -348,59 +372,6 @@ def is_between(
 <section>
 <h2 class="section-title" id="header-functions">Functions</h2>
 <dl>
-<dt id="dynamicio.validations.has_acceptable_categorical_values"><code class="name flex">
-<span>def <span class="ident">has_acceptable_categorical_values</span></span>(<span>dataset: str, df: pandas.core.frame.DataFrame, column: str, categorical_values: Set[str]) ‑> dynamicio.validations.ValidationResult</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Checks if the column only has allowed categorical values as per the set provided.</p>
-<h2 id="note">Note</h2>
-<p>Ignores nulls</p>
-<h2 id="args">Args</h2>
-<dl>
-<dt><strong><code>dataset</code></strong></dt>
-<dd>Name fo the dataset_name</dd>
-<dt><strong><code>df</code></strong></dt>
-<dd>A DataFrame</dd>
-<dt><strong><code>column</code></strong></dt>
-<dd>The DataFrame column to be validated</dd>
-<dt><strong><code>categorical_values</code></strong></dt>
-<dd>The allowed set of categorical values</dd>
-</dl>
-<h2 id="returns">Returns</h2>
-<p>An instance of ValidationResult where <code>Validation.Result.valid</code> is a bool indicate the success of the validation,
-<code>Validation.Result.message</code> is a message (usually used in exceptions), and <code>Validation.Result.value</code> is no_of_not_acceptable</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def has_acceptable_categorical_values(dataset: str, df: pd.DataFrame, column: str, categorical_values: Set[str]) -&gt; ValidationResult:
-    &#34;&#34;&#34;Checks if the column only has allowed categorical values as per the set provided.
-
-    Note:
-        Ignores nulls
-
-    Args:
-        dataset: Name fo the dataset_name
-        df: A DataFrame
-        column: The DataFrame column to be validated
-        categorical_values: The allowed set of categorical values
-
-    Returns:
-        An instance of ValidationResult where `Validation.Result.valid` is a bool indicate the success of the validation,
-        `Validation.Result.message` is a message (usually used in exceptions), and `Validation.Result.value` is no_of_not_acceptable
-    &#34;&#34;&#34;
-    unique_values = set(df[column][df[column].notna()].unique())
-    if unique_values.issubset(categorical_values):
-        return ValidationResult(valid=True, message=f&#34;Categorical values for {dataset}[{column}] are acceptable&#34;, value=0)
-
-    count_invalid = (~df[column].isin(categorical_values)).sum()
-    return ValidationResult(
-        valid=False,
-        message=f&#34;Values {unique_values - set(categorical_values)} for {dataset}[{column}] are not acceptable for {count_invalid} cells&#34;,
-        value=count_invalid,
-    )</code></pre>
-</details>
-</dd>
 <dt id="dynamicio.validations.has_acceptable_percentage_of_nulls"><code class="name flex">
 <span>def <span class="ident">has_acceptable_percentage_of_nulls</span></span>(<span>dataset: str, df: pandas.core.frame.DataFrame, column: str, threshold: float) ‑> dynamicio.validations.ValidationResult</span>
 </code></dt>
@@ -740,6 +711,57 @@ percentage of invalid values</p></div>
     )</code></pre>
 </details>
 </dd>
+<dt id="dynamicio.validations.is_in"><code class="name flex">
+<span>def <span class="ident">is_in</span></span>(<span>dataset: str, df: pandas.core.frame.DataFrame, column: str, categorical_values: Set[str], match_all: bool = True) ‑> dynamicio.validations.ValidationResult</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Checks if the column only has allowed categorical values as per the set provided.</p>
+<h2 id="note">Note</h2>
+<p>Ignores nulls</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>dataset</code></strong></dt>
+<dd>Name fo the dataset_name</dd>
+<dt><strong><code>df</code></strong></dt>
+<dd>A DataFrame</dd>
+<dt><strong><code>column</code></strong></dt>
+<dd>The DataFrame column to be validated</dd>
+<dt><strong><code>categorical_values</code></strong></dt>
+<dd>The allowed set of categorical values</dd>
+<dt><strong><code>match_all</code></strong></dt>
+<dd>If True, the categorical values must be a subset of the allowed set, otherwise they must be equal</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>An instance of ValidationResult where <code>Validation.Result.valid</code> is a bool indicate the success of the validation,
+<code>Validation.Result.message</code> is a message (usually used in exceptions), and <code>Validation.Result.value</code> is no_of_not_acceptable</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def is_in(dataset: str, df: pd.DataFrame, column: str, categorical_values: Set[str], match_all: bool = True) -&gt; ValidationResult:
+    &#34;&#34;&#34;Checks if the column only has allowed categorical values as per the set provided.
+
+    Note:
+        Ignores nulls
+
+    Args:
+        dataset: Name fo the dataset_name
+        df: A DataFrame
+        column: The DataFrame column to be validated
+        categorical_values: The allowed set of categorical values
+        match_all: If True, the categorical values must be a subset of the allowed set, otherwise they must be equal
+
+    Returns:
+        An instance of ValidationResult where `Validation.Result.valid` is a bool indicate the success of the validation,
+        `Validation.Result.message` is a message (usually used in exceptions), and `Validation.Result.value` is no_of_not_acceptable
+    &#34;&#34;&#34;
+    unique_values = set(df[column][df[column].notna()].unique())
+
+    if match_all:
+        return _validate_categoricals_are_a_subset_of_the_acceptable(categorical_values, unique_values, column, dataset, df)
+    return _validate_all_acceptable_categoricals_are_present(categorical_values, unique_values, column, dataset, df)</code></pre>
+</details>
+</dd>
 <dt id="dynamicio.validations.is_lower_than"><code class="name flex">
 <span>def <span class="ident">is_lower_than</span></span>(<span>dataset: str, df: pandas.core.frame.DataFrame, column: str, threshold: float) ‑> dynamicio.validations.ValidationResult</span>
 </code></dt>
@@ -878,13 +900,13 @@ invalid values</p></div>
 </li>
 <li><h3><a href="#header-functions">Functions</a></h3>
 <ul class="">
-<li><code><a title="dynamicio.validations.has_acceptable_categorical_values" href="#dynamicio.validations.has_acceptable_categorical_values">has_acceptable_categorical_values</a></code></li>
 <li><code><a title="dynamicio.validations.has_acceptable_percentage_of_nulls" href="#dynamicio.validations.has_acceptable_percentage_of_nulls">has_acceptable_percentage_of_nulls</a></code></li>
 <li><code><a title="dynamicio.validations.has_no_null_values" href="#dynamicio.validations.has_no_null_values">has_no_null_values</a></code></li>
 <li><code><a title="dynamicio.validations.has_unique_values" href="#dynamicio.validations.has_unique_values">has_unique_values</a></code></li>
 <li><code><a title="dynamicio.validations.is_between" href="#dynamicio.validations.is_between">is_between</a></code></li>
 <li><code><a title="dynamicio.validations.is_greater_than" href="#dynamicio.validations.is_greater_than">is_greater_than</a></code></li>
 <li><code><a title="dynamicio.validations.is_greater_than_or_equal" href="#dynamicio.validations.is_greater_than_or_equal">is_greater_than_or_equal</a></code></li>
+<li><code><a title="dynamicio.validations.is_in" href="#dynamicio.validations.is_in">is_in</a></code></li>
 <li><code><a title="dynamicio.validations.is_lower_than" href="#dynamicio.validations.is_lower_than">is_lower_than</a></code></li>
 <li><code><a title="dynamicio.validations.is_lower_than_or_equal" href="#dynamicio.validations.is_lower_than_or_equal">is_lower_than_or_equal</a></code></li>
 </ul>

--- a/dynamicio/core.py
+++ b/dynamicio/core.py
@@ -176,12 +176,7 @@ class DynamicDataIO:
         for column in self.schema_validations.keys():
             for validation in self.schema_validations[column].keys():
                 if self.schema_validations[column][validation]["apply"] is True:
-                    validation_result = getattr(validations, validation)(
-                        self.name,
-                        df,
-                        column,
-                        **self.schema_validations[column][validation]["options"],
-                    )
+                    validation_result = getattr(validations, validation)(self.name, df, column, **self.schema_validations[column][validation]["options"])
                     if not validation_result.valid:
                         failed_validations[validation] = validation_result.message
 

--- a/dynamicio/validations.py
+++ b/dynamicio/validations.py
@@ -130,19 +130,21 @@ def is_in(dataset: str, df: pd.DataFrame, column: str, categorical_values: Set[s
 
 def _validate_all_acceptable_categoricals_are_present(acceptable_categoricals: Set[str], unique_values: Set[str], column: str, dataset: str, df: pd.DataFrame) -> ValidationResult:
     if unique_values == acceptable_categoricals:
-        return ValidationResult(valid=True, message=f"All acceptable categorical values for {dataset}[{column}] are present", value=0)
-    if unique_values < acceptable_categoricals:
-        return ValidationResult(
+        validation_result = ValidationResult(valid=True, message=f"All acceptable categorical values for {dataset}[{column}] are present", value=0)
+    elif unique_values < acceptable_categoricals:
+        validation_result = ValidationResult(
             valid=False,
             message=f"Missing categorical values for {dataset}[{column}]: {acceptable_categoricals - unique_values}",
             value=len(acceptable_categoricals - unique_values),
         )
-    count_invalid = (~df[column].isin(acceptable_categoricals)).sum()
-    return ValidationResult(
-        valid=False,
-        message=f"Values {unique_values - set(acceptable_categoricals)} for {dataset}[{column}] are not acceptable for {count_invalid} cells",
-        value=count_invalid,
-    )
+    else:
+        count_invalid = (~df[column].isin(acceptable_categoricals)).sum()
+        validation_result = ValidationResult(
+            valid=False,
+            message=f"Values {unique_values - set(acceptable_categoricals)} for {dataset}[{column}] are not acceptable for {count_invalid} cells",
+            value=count_invalid,
+        )
+    return validation_result
 
 
 def _validate_categoricals_are_a_subset_of_the_acceptable(acceptable_categoricals: Set[str], unique_values: Set[str], column: str, dataset: str, df: pd.DataFrame) -> ValidationResult:

--- a/dynamicio/validations.py
+++ b/dynamicio/validations.py
@@ -3,7 +3,7 @@ __all__ = [
     "has_unique_values",
     "has_no_null_values",
     "has_acceptable_percentage_of_nulls",
-    "has_acceptable_categorical_values",
+    "is_in",
     "is_greater_than",
     "is_greater_than_or_equal",
     "is_lower_than",
@@ -104,7 +104,7 @@ def has_acceptable_percentage_of_nulls(
     )
 
 
-def has_acceptable_categorical_values(dataset: str, df: pd.DataFrame, column: str, categorical_values: Set[str], is_subset: bool = True) -> ValidationResult:
+def is_in(dataset: str, df: pd.DataFrame, column: str, categorical_values: Set[str], match_all: bool = True) -> ValidationResult:
     """Checks if the column only has allowed categorical values as per the set provided.
 
     Note:
@@ -115,7 +115,7 @@ def has_acceptable_categorical_values(dataset: str, df: pd.DataFrame, column: st
         df: A DataFrame
         column: The DataFrame column to be validated
         categorical_values: The allowed set of categorical values
-        is_subset: If True, the categorical values must be a subset of the allowed set, otherwise they must be equal
+        match_all: If True, the categorical values must be a subset of the allowed set, otherwise they must be equal
 
     Returns:
         An instance of ValidationResult where `Validation.Result.valid` is a bool indicate the success of the validation,
@@ -123,7 +123,7 @@ def has_acceptable_categorical_values(dataset: str, df: pd.DataFrame, column: st
     """
     unique_values = set(df[column][df[column].notna()].unique())
 
-    if is_subset:
+    if match_all:
         return _validate_categoricals_are_a_subset_of_the_acceptable(categorical_values, unique_values, column, dataset, df)
     return _validate_all_acceptable_categoricals_are_present(categorical_values, unique_values, column, dataset, df)
 

--- a/dynamicio/validations.py
+++ b/dynamicio/validations.py
@@ -104,7 +104,7 @@ def has_acceptable_percentage_of_nulls(
     )
 
 
-def has_acceptable_categorical_values(dataset: str, df: pd.DataFrame, column: str, categorical_values: Set[str]) -> ValidationResult:
+def has_acceptable_categorical_values(dataset: str, df: pd.DataFrame, column: str, categorical_values: Set[str], is_subset: bool = True) -> ValidationResult:
     """Checks if the column only has allowed categorical values as per the set provided.
 
     Note:
@@ -115,19 +115,43 @@ def has_acceptable_categorical_values(dataset: str, df: pd.DataFrame, column: st
         df: A DataFrame
         column: The DataFrame column to be validated
         categorical_values: The allowed set of categorical values
+        is_subset: If True, the categorical values must be a subset of the allowed set, otherwise they must be equal
 
     Returns:
         An instance of ValidationResult where `Validation.Result.valid` is a bool indicate the success of the validation,
         `Validation.Result.message` is a message (usually used in exceptions), and `Validation.Result.value` is no_of_not_acceptable
     """
     unique_values = set(df[column][df[column].notna()].unique())
-    if unique_values.issubset(categorical_values):
-        return ValidationResult(valid=True, message=f"Categorical values for {dataset}[{column}] are acceptable", value=0)
 
-    count_invalid = (~df[column].isin(categorical_values)).sum()
+    if is_subset:
+        return _validate_categoricals_are_a_subset_of_the_acceptable(categorical_values, unique_values, column, dataset, df)
+    return _validate_all_acceptable_categoricals_are_present(categorical_values, unique_values, column, dataset, df)
+
+
+def _validate_all_acceptable_categoricals_are_present(acceptable_categoricals: Set[str], unique_values: Set[str], column: str, dataset: str, df: pd.DataFrame) -> ValidationResult:
+    if unique_values == acceptable_categoricals:
+        return ValidationResult(valid=True, message=f"All acceptable categorical values for {dataset}[{column}] are present", value=0)
+    if unique_values < acceptable_categoricals:
+        return ValidationResult(
+            valid=False,
+            message=f"Missing categorical values for {dataset}[{column}]: {acceptable_categoricals - unique_values}",
+            value=len(acceptable_categoricals - unique_values),
+        )
+    count_invalid = (~df[column].isin(acceptable_categoricals)).sum()
     return ValidationResult(
         valid=False,
-        message=f"Values {unique_values - set(categorical_values)} for {dataset}[{column}] are not acceptable for {count_invalid} cells",
+        message=f"Values {unique_values - set(acceptable_categoricals)} for {dataset}[{column}] are not acceptable for {count_invalid} cells",
+        value=count_invalid,
+    )
+
+
+def _validate_categoricals_are_a_subset_of_the_acceptable(acceptable_categoricals: Set[str], unique_values: Set[str], column: str, dataset: str, df: pd.DataFrame) -> ValidationResult:
+    if unique_values.issubset(acceptable_categoricals):
+        return ValidationResult(valid=True, message=f"Categorical values for {dataset}[{column}] are acceptable", value=0)
+    count_invalid = (~df[column].isin(acceptable_categoricals)).sum()
+    return ValidationResult(
+        valid=False,
+        message=f"Values {unique_values - set(acceptable_categoricals)} for {dataset}[{column}] are not acceptable for {count_invalid} cells",
         value=count_invalid,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,7 +244,7 @@ def expected_s3_csv_local_mapping():
                 "is_lower_than": {"apply": True, "options": {"threshold": 2000}},
             },
             "foo_name": {
-                "has_acceptable_categorical_values": {
+                "is_in": {
                     "apply": True,
                     "options": {"categorical_values": ["class_a", "class_b", "class_c"]},
                 },
@@ -277,7 +277,7 @@ def expected_s3_csv_cloud_mapping():
                 "is_lower_than": {"apply": True, "options": {"threshold": 2000}},
             },
             "foo_name": {
-                "has_acceptable_categorical_values": {
+                "is_in": {
                     "apply": True,
                     "options": {"categorical_values": ["class_a", "class_b", "class_c"]},
                 },
@@ -435,7 +435,7 @@ def input_schema_definition():
                 "metrics": None,
                 "type": "object",
                 "validations": {
-                    "has_acceptable_categorical_values": {
+                    "is_in": {
                         "apply": True,
                         "options": {"categorical_values": ["class_a", "class_b", "class_c"]},
                     },
@@ -477,7 +477,7 @@ def expected_schema_definition():
                 "metrics": ["CountsPerLabel"],
                 "type": "object",
                 "validations": {
-                    "has_acceptable_categorical_values": {
+                    "is_in": {
                         "apply": True,
                         "options": {"categorical_values": ["class_a", "class_b", "class_c"]},
                     },
@@ -502,7 +502,7 @@ def expected_validations():
             "is_lower_than": {"apply": True, "options": {"threshold": 2000}},
         },
         "foo_name": {
-            "has_acceptable_categorical_values": {
+            "is_in": {
                 "apply": True,
                 "options": {"categorical_values": ["class_a", "class_b", "class_c"]},
             },
@@ -546,7 +546,7 @@ def invalid_dataframe():
 def expected_messages():
     return {
         "has_unique_values",
-        "has_acceptable_categorical_values",
+        "is_in",
         "is_greater_than",
         "is_lower_than",
     }

--- a/tests/resources/schemas/foo.yaml
+++ b/tests/resources/schemas/foo.yaml
@@ -40,6 +40,7 @@ columns:
             - class_a
             - class_b
             - class_c
+          is_subset: true # true by default
       has_no_null_values:
         apply: true
         options:

--- a/tests/resources/schemas/foo.yaml
+++ b/tests/resources/schemas/foo.yaml
@@ -40,7 +40,7 @@ columns:
             - class_a
             - class_b
             - class_c
-          is_subset: true # true by default
+          is_subset: false # true by default, if false, then the column unique categoricals must be equal to the acceptable ones, else they must be a subset
       has_no_null_values:
         apply: true
         options:

--- a/tests/resources/schemas/foo.yaml
+++ b/tests/resources/schemas/foo.yaml
@@ -33,14 +33,14 @@ columns:
   category:
     type: "object"
     validations:
-      has_acceptable_categorical_values:
+      is_in:
         apply: true
         options:
           categorical_values:
             - class_a
             - class_b
             - class_c
-          is_subset: false # true by default, if false, then the column unique categoricals must be equal to the acceptable ones, else they must be a subset
+          match_all: false # true by default, if false, then the column unique categoricals must be equal to the acceptable ones, else they must be a subset
       has_no_null_values:
         apply: true
         options:

--- a/tests/resources/schemas/read_from_s3_csv.yaml
+++ b/tests/resources/schemas/read_from_s3_csv.yaml
@@ -19,7 +19,7 @@ columns:
       has_no_null_values:
         apply: true
         options: {}
-      has_acceptable_categorical_values:
+      is_in:
         apply: true
         options:
           categorical_values:

--- a/tests/resources/schemas/write_to_s3_csv.yaml
+++ b/tests/resources/schemas/write_to_s3_csv.yaml
@@ -17,7 +17,7 @@ columns:
       has_no_null_values:
         apply: true
         options: {}
-      has_acceptable_categorical_values:
+      is_in:
         apply: true
         options:
           categorical_values:

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -2,13 +2,13 @@
 import pytest
 
 from dynamicio.validations import (
-    has_acceptable_categorical_values,
     has_acceptable_percentage_of_nulls,
     has_no_null_values,
     has_unique_values,
     is_between,
     is_greater_than,
     is_greater_than_or_equal,
+    is_in,
     is_lower_than,
     is_lower_than_or_equal,
 )
@@ -144,7 +144,7 @@ class TestHasAcceptableCategoricalValues:
         df = input_df
 
         # When
-        validation = has_acceptable_categorical_values(
+        validation = is_in(
             "TEST",
             df,
             column="activity",
@@ -155,34 +155,34 @@ class TestHasAcceptableCategoricalValues:
         assert validation.valid is True and validation.value == 0 and validation.message == "Categorical values for TEST[activity] are acceptable"
 
     @pytest.mark.unit
-    def test_returns_true_only_if_columns_unique_vals_are_an_exact_match_of_the_input_set_when_is_subset_is_set_to_false(self, input_df):
+    def test_returns_true_only_if_columns_unique_vals_are_an_exact_match_of_the_input_set_when_match_all_is_set_to_false(self, input_df):
         # Given
         df = input_df
 
         # When
-        validation = has_acceptable_categorical_values("TEST", df, column="activity", categorical_values={"load", "discharge", "pass_through"}, is_subset=False)
+        validation = is_in("TEST", df, column="activity", categorical_values={"load", "discharge", "pass_through"}, match_all=False)
 
         # Then
         assert validation.valid is True and validation.value == 0 and validation.message == "All acceptable categorical values for TEST[activity] are present"
 
     @pytest.mark.unit
-    def test_returns_false_if_columns_unique_vals_are_less_than_the_acceptable_categoricals_when_is_subset_is_set_to_false(self, input_df):
+    def test_returns_false_if_columns_unique_vals_are_less_than_the_acceptable_categoricals_when_match_all_is_set_to_false(self, input_df):
         # Given
         df = input_df
 
         # When
-        validation = has_acceptable_categorical_values("TEST", df, column="activity", categorical_values={"load", "discharge", "pass_through", "one_more"}, is_subset=False)
+        validation = is_in("TEST", df, column="activity", categorical_values={"load", "discharge", "pass_through", "one_more"}, match_all=False)
 
         # Then
         assert validation.valid is False and validation.value == 1 and validation.message == "Missing categorical values for TEST[activity]: {'one_more'}"
 
     @pytest.mark.unit
-    def test_returns_false_if_columns_unique_vals_are_more_than_the_acceptable_categoricals_when_is_subset_is_set_to_false(self, input_df):
+    def test_returns_false_if_columns_unique_vals_are_more_than_the_acceptable_categoricals_when_match_all_is_set_to_false(self, input_df):
         # Given
         df = input_df
 
         # When
-        validation = has_acceptable_categorical_values("TEST", df, column="activity", categorical_values={"load", "discharge"}, is_subset=False)
+        validation = is_in("TEST", df, column="activity", categorical_values={"load", "discharge"}, match_all=False)
 
         # Then
         assert validation.valid is False and validation.value == 3 and validation.message == "Values {'pass_through'} for TEST[activity] are not acceptable for 3 cells"
@@ -193,7 +193,7 @@ class TestHasAcceptableCategoricalValues:
         df = input_df
 
         # When/Then
-        validation = has_acceptable_categorical_values("TEST", df, column="activity", categorical_values={"load", "discharge", "pass_through"})
+        validation = is_in("TEST", df, column="activity", categorical_values={"load", "discharge", "pass_through"})
 
         # Then
         assert validation.valid is True and validation.value == 0 and validation.message == "Categorical values for TEST[activity] are acceptable"
@@ -204,7 +204,7 @@ class TestHasAcceptableCategoricalValues:
         df = input_df
 
         # When/Then
-        validation = has_acceptable_categorical_values("TEST", df, column="activity", categorical_values={"load", "pass_through"})
+        validation = is_in("TEST", df, column="activity", categorical_values={"load", "pass_through"})
 
         # Then
         assert not validation.valid and validation.value == 5 and validation.message == "Values {'discharge'} for TEST[activity] are not acceptable for 5 cells"
@@ -215,7 +215,7 @@ class TestHasAcceptableCategoricalValues:
         df = input_df
 
         # When
-        validation = has_acceptable_categorical_values("TEST", df, column="category_a", categorical_values={"A", "B", "C", None})
+        validation = is_in("TEST", df, column="category_a", categorical_values={"A", "B", "C", None})
 
         # Then
         assert validation.valid is True and validation.value == 0 and validation.message == "Categorical values for TEST[category_a] are acceptable"
@@ -226,7 +226,7 @@ class TestHasAcceptableCategoricalValues:
         df = input_df
 
         # When
-        validation = has_acceptable_categorical_values("TEST", df, column="category_a", categorical_values={"A", "B", "C"})
+        validation = is_in("TEST", df, column="category_a", categorical_values={"A", "B", "C"})
 
         # Then
         assert validation.valid is True and validation.value == 0 and validation.message == "Categorical values for TEST[category_a] are acceptable"
@@ -237,7 +237,7 @@ class TestHasAcceptableCategoricalValues:
         df = input_df  # where category_b has None, pd.NA and np.nan values
 
         # When
-        validation = has_acceptable_categorical_values("TEST", df, column="category_b", categorical_values={"A", "B", "C", None})
+        validation = is_in("TEST", df, column="category_b", categorical_values={"A", "B", "C", None})
 
         # Then
         assert validation.valid is True and validation.value == 0 and validation.message == "Categorical values for TEST[category_b] are acceptable"
@@ -248,7 +248,7 @@ class TestHasAcceptableCategoricalValues:
         df = input_df  # where category_b has None, pd.NA and np.nan values
 
         # When
-        validation = has_acceptable_categorical_values("TEST", df, column="category_b", categorical_values={"A", "B", "C"})
+        validation = is_in("TEST", df, column="category_b", categorical_values={"A", "B", "C"})
 
         # Then
         assert validation.valid is True and validation.value == 0 and validation.message == "Categorical values for TEST[category_b] are acceptable"

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -27,7 +27,7 @@ class TestHasUniqueValues:
         assert validation.valid is True and validation.value == 0 and validation.message == "TEST[id] has unique values"
 
     @pytest.mark.unit
-    def test_eturns_false_if_column_has_duplicate_values(self, input_df):
+    def test_returns_false_if_column_has_duplicate_values(self, input_df):
         # Given
         df = input_df
 
@@ -153,6 +153,39 @@ class TestHasAcceptableCategoricalValues:
 
         # Then
         assert validation.valid is True and validation.value == 0 and validation.message == "Categorical values for TEST[activity] are acceptable"
+
+    @pytest.mark.unit
+    def test_returns_true_only_if_columns_unique_vals_are_an_exact_match_of_the_input_set_when_is_subset_is_set_to_false(self, input_df):
+        # Given
+        df = input_df
+
+        # When
+        validation = has_acceptable_categorical_values("TEST", df, column="activity", categorical_values={"load", "discharge", "pass_through"}, is_subset=False)
+
+        # Then
+        assert validation.valid is True and validation.value == 0 and validation.message == "All acceptable categorical values for TEST[activity] are present"
+
+    @pytest.mark.unit
+    def test_returns_false_if_columns_unique_vals_are_less_than_the_acceptable_categoricals_when_is_subset_is_set_to_false(self, input_df):
+        # Given
+        df = input_df
+
+        # When
+        validation = has_acceptable_categorical_values("TEST", df, column="activity", categorical_values={"load", "discharge", "pass_through", "one_more"}, is_subset=False)
+
+        # Then
+        assert validation.valid is False and validation.value == 1 and validation.message == "Missing categorical values for TEST[activity]: {'one_more'}"
+
+    @pytest.mark.unit
+    def test_returns_false_if_columns_unique_vals_are_more_than_the_acceptable_categoricals_when_is_subset_is_set_to_false(self, input_df):
+        # Given
+        df = input_df
+
+        # When
+        validation = has_acceptable_categorical_values("TEST", df, column="activity", categorical_values={"load", "discharge"}, is_subset=False)
+
+        # Then
+        assert validation.valid is False and validation.value == 3 and validation.message == "Values {'pass_through'} for TEST[activity] are not acceptable for 3 cells"
 
     @pytest.mark.unit
     def test_returns_true_if_columns_unique_vals_are_an_exact_match_of_the_input_set(self, input_df):


### PR DESCRIPTION
## Overview

In rare occasions, we may want to validate that the categoricals in a column are not just a subset of an acceptable set, but they are equal to it, i.e. that all acceptable categoricals are present. 

## Key Changes

* Extended `has_acceptable_categorical_values` to take another option, `is_subset`. The option's default value is `True`. If set to false, then the validation will be stricter and will require that all acceptable categoricals are present in the column.

Example:
```yaml 
---
name: foo
columns:
  category:
    type: "object"
    validations:
      has_acceptable_categorical_values:  # renamed to `isin`
        apply: true
        options:
          categorical_values:
            - class_a
            - class_b
            - class_c
          is_subset: false # renamed to `match_all`:  true by default, if false, then the column unique categoricals must be equal to the acceptable ones, else they must be a subset
      has_no_null_values:
        apply: true
        options:
```
## Checklist

- [x] Appropriate unit tests added/updated
- [x] Module, function, class docstrings updated
- [x] Comments added to PR where necessary
- [x] Interface documentation updated
- [x] Semantic commits used for this PR, so that a CHANGELOG can be generated from them (don't delete your local branch! when tagging a new release from master)

## Release-Steps

- [ ] Merge PR
- [ ] Release new tag
