### PR TITLE
fix: Confirm floats are not returned unless a repl takes place

### DIFF
--- a/dynamicio/config.py
+++ b/dynamicio/config.py
@@ -143,11 +143,12 @@ class SafeDynamicSchemaLoader(yaml.SafeLoader):
 
             value = self.dynamic_data_matcher.sub(f"\\g<1>{replacement}\\g<4>", value)
 
-        try:
-            value = float(value)
-            return value
-        except ValueError:
-            pass
+            try:
+                value = float(value)
+                return value
+            except ValueError:
+                pass
+
         return value
 
 

--- a/tests/resources/schemas/bar.yaml
+++ b/tests/resources/schemas/bar.yaml
@@ -38,3 +38,11 @@ columns:
       - Mean
       - Std
       - Variance
+  "0":
+    type: "object"
+    validations: {}
+    metrics: []
+  1:
+    type: "object"
+    validations: {}
+    metrics: []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -148,6 +148,32 @@ class TestIOConfig:
         # Then
         assert my_config["validations"]["column_c"]["is_greater_than"]["options"]["threshold"] == 1000
 
+    @pytest.mark.unit
+    def test__get_schema_definition_returns_float_only_in_case_of_replacements(self):
+        # Given
+        input_config = IOConfig(
+            path_to_source_yaml=(os.path.join(constants.TEST_RESOURCES, "definitions/test_input.yaml")),
+            env_identifier="LOCAL",
+            dynamic_vars=constants,
+        )
+
+        # When
+        my_config = input_config.get(source_key="REPLACE_SCHEMA_WITH_DYN_VARS")
+
+        # Then
+        key_types_dict = {}
+        for key in my_config["schema"]:
+            key_types_dict[key] = str(type(key))
+
+        assert key_types_dict == {
+            "column_a": "<class 'str'>",
+            "column_b": "<class 'str'>",
+            "column_c": "<class 'str'>",
+            "column_d": "<class 'str'>",
+            "0": "<class 'str'>",  # This is a string (as per the schema definition))
+            1: "<class 'int'>",  # This is not a float!
+        }
+
 
 class TestSafeDynamicLoader:  # pylint: disable=R0903
     @pytest.mark.unit


### PR DESCRIPTION
## Overview

The introduction of this PR: https://github.com/VorTECHsa/dynamicio/pull/27 has corrupted how certain values in a schema definitions, specifically related to column names can be parsed as floats rather than ints or strs. This results in errors when parsing schemas where a column key is set to a number, e.g.:

```yaml
---
name: bar
columns:
  "0":   # This should be a string and not a float
    type: "object"
    validations: {}
    metrics: []
  1:       # This should be an int and not a float
    type: "object"
    validations: {}
    metrics: [] 
```
## Key Changes

* Schema parser is adjusted to apply casting of parsed values only in case of replacements. 


## Checklist

- [x] Appropriate unit tests added/updated
- [x] Module, function, class docstrings updated
- [x] Comments added to PR where necessary
- [x] Interface documentation updated
- [x] Semantic commits used for this PR, so that a CHANGELOG can be generated from them (don't delete your local branch! when tagging a new release from master)

## Release-Steps

- [ ] Merge PR
- [ ] Release new tag
