### PR TITLE
feat: Add truncate and append functionality to Postgres writer

### DIFF
--- a/docs/mixins.html
+++ b/docs/mixins.html
@@ -795,16 +795,13 @@ class WithPostgres:
             query = query.with_session(session).statement
         return pd.read_sql(sql=query, con=session.get_bind(), **options)
 
-    def _write_to_postgres(self, df: pd.DataFrame):
+    @allow_options([&#34;truncate_and_append&#34;])
+    def _write_to_postgres(self, df: pd.DataFrame, **options: Any):
         &#34;&#34;&#34;Write a dataframe to postgres based on the {file_type} of the config_io configuration.
 
         Args:
             df: The dataframe to be written
         &#34;&#34;&#34;
-        # engine = sqlalchemy.create_engine(f&#34;postgresql://{USER}:{PASSWORD}@{HOST}:{PORT}/{DB_NAME}&#34;)
-        # conn = engine.connect()
-        # cm_volumes.to_sql(&#34;cm_volumes&#34;, engine, if_exists=&#34;append&#34;, index=False)
-
         postgres_config = self.sources_config[&#34;postgres&#34;]
         db_user = postgres_config[&#34;db_user&#34;]
         db_password = postgres_config[&#34;db_password&#34;]
@@ -818,19 +815,28 @@ class WithPostgres:
         schema_name = self.sources_config[&#34;name&#34;]
         model = self._generate_model_from_schema(schema_dict, schema_name)
 
+        if is_truncate_and_append := options.get(&#34;truncate_and_append&#34;, False):
+            options.pop(&#34;truncate_and_append&#34;)
+
         with session_for(connection_string) as session:
-            self._write_to_database(session, model.__tablename__, df)  # type: ignore
+            self._write_to_database(session, model.__tablename__, df, is_truncate_and_append)  # type: ignore
 
     @staticmethod
-    def _write_to_database(session: SqlAlchemySession, table_name: str, df: pd.DataFrame):
+    def _write_to_database(session: SqlAlchemySession, table_name: str, df: pd.DataFrame, is_truncate_and_append: bool):
         &#34;&#34;&#34;Write a dataframe to any database provided a session with a data model and a table name.
 
         Args:
             session: Generated from a data model and a table name
             table_name: The name of the table to read from a DB
             df: The dataframe to be written out
+            is_truncate_and_append: Supply to truncate the table and append new rows to it; otherwise, delete and replace
         &#34;&#34;&#34;
-        df.to_sql(name=table_name, con=session.get_bind(), if_exists=&#34;replace&#34;, index=False)
+        if is_truncate_and_append:
+            session.execute(f&#34;TRUNCATE TABLE {table_name};&#34;)
+            df.to_sql(name=table_name, con=session.get_bind(), if_exists=&#34;append&#34;, index=False)
+        else:
+            df.to_sql(name=table_name, con=session.get_bind(), if_exists=&#34;replace&#34;, index=False)
+
         session.commit()
 
 
@@ -1781,16 +1787,13 @@ Kafka topic.</p>
             query = query.with_session(session).statement
         return pd.read_sql(sql=query, con=session.get_bind(), **options)
 
-    def _write_to_postgres(self, df: pd.DataFrame):
+    @allow_options([&#34;truncate_and_append&#34;])
+    def _write_to_postgres(self, df: pd.DataFrame, **options: Any):
         &#34;&#34;&#34;Write a dataframe to postgres based on the {file_type} of the config_io configuration.
 
         Args:
             df: The dataframe to be written
         &#34;&#34;&#34;
-        # engine = sqlalchemy.create_engine(f&#34;postgresql://{USER}:{PASSWORD}@{HOST}:{PORT}/{DB_NAME}&#34;)
-        # conn = engine.connect()
-        # cm_volumes.to_sql(&#34;cm_volumes&#34;, engine, if_exists=&#34;append&#34;, index=False)
-
         postgres_config = self.sources_config[&#34;postgres&#34;]
         db_user = postgres_config[&#34;db_user&#34;]
         db_password = postgres_config[&#34;db_password&#34;]
@@ -1804,19 +1807,28 @@ Kafka topic.</p>
         schema_name = self.sources_config[&#34;name&#34;]
         model = self._generate_model_from_schema(schema_dict, schema_name)
 
+        if is_truncate_and_append := options.get(&#34;truncate_and_append&#34;, False):
+            options.pop(&#34;truncate_and_append&#34;)
+
         with session_for(connection_string) as session:
-            self._write_to_database(session, model.__tablename__, df)  # type: ignore
+            self._write_to_database(session, model.__tablename__, df, is_truncate_and_append)  # type: ignore
 
     @staticmethod
-    def _write_to_database(session: SqlAlchemySession, table_name: str, df: pd.DataFrame):
+    def _write_to_database(session: SqlAlchemySession, table_name: str, df: pd.DataFrame, is_truncate_and_append: bool):
         &#34;&#34;&#34;Write a dataframe to any database provided a session with a data model and a table name.
 
         Args:
             session: Generated from a data model and a table name
             table_name: The name of the table to read from a DB
             df: The dataframe to be written out
+            is_truncate_and_append: Supply to truncate the table and append new rows to it; otherwise, delete and replace
         &#34;&#34;&#34;
-        df.to_sql(name=table_name, con=session.get_bind(), if_exists=&#34;replace&#34;, index=False)
+        if is_truncate_and_append:
+            session.execute(f&#34;TRUNCATE TABLE {table_name};&#34;)
+            df.to_sql(name=table_name, con=session.get_bind(), if_exists=&#34;append&#34;, index=False)
+        else:
+            df.to_sql(name=table_name, con=session.get_bind(), if_exists=&#34;replace&#34;, index=False)
+
         session.commit()</code></pre>
 </details>
 <h3>Subclasses</h3>

--- a/docs/mixins.html
+++ b/docs/mixins.html
@@ -701,7 +701,12 @@ class WithS3File(WithLocal):
 
 
 class WithPostgres:
-    &#34;&#34;&#34;Handles I/O operations for Postgres.&#34;&#34;&#34;
+    &#34;&#34;&#34;Handles I/O operations for Postgres.
+
+     Args:
+        - options:
+            - `truncate_and_append: bool`: If set to `True`, truncates the table and then appends the new rows. Otherwise, it drops the table and recreates it with the new rows.
+    &#34;&#34;&#34;
 
     sources_config: Mapping
     schema: Mapping
@@ -796,7 +801,7 @@ class WithPostgres:
         return pd.read_sql(sql=query, con=session.get_bind(), **options)
 
     @allow_options([&#34;truncate_and_append&#34;])
-    def _write_to_postgres(self, df: pd.DataFrame, **options: Any):
+    def _write_to_postgres(self, df: pd.DataFrame, **options: MutableMapping[str, Any]):
         &#34;&#34;&#34;Write a dataframe to postgres based on the {file_type} of the config_io configuration.
 
         Args:
@@ -1687,24 +1692,25 @@ Kafka topic.</p>
 <span>class <span class="ident">WithPostgres</span></span>
 </code></dt>
 <dd>
-<div class="desc">
-    <p>Handles I/O operations for Kafka.</p>
-</div>
+<div class="desc"><p>Handles I/O operations for Postgres.</p>
 <h2 id="args">Args</h2>
 <ul>
-    <li>options:</li>
-    <ul>
-        <li><code>truncate_and_append: bool</code>: If set to <code>True</code>, truncates the table and then appends the new rows. Otherwise, it drops the table and recreates it with the new rows.</li>
-    </ul>
+<li>options:<ul>
+<li><code>truncate_and_append: bool</code>: If set to <code>True</code>, truncates the table and then appends the new rows. Otherwise, it drops the table and recreates it with the new rows.</li>
 </ul>
-
-<div class="desc"><p>Handles I/O operations for Postgres.</p></div>
+</li>
+</ul></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">class WithPostgres:
-    &#34;&#34;&#34;Handles I/O operations for Postgres.&#34;&#34;&#34;
+    &#34;&#34;&#34;Handles I/O operations for Postgres.
+
+     Args:
+        - options:
+            - `truncate_and_append: bool`: If set to `True`, truncates the table and then appends the new rows. Otherwise, it drops the table and recreates it with the new rows.
+    &#34;&#34;&#34;
 
     sources_config: Mapping
     schema: Mapping
@@ -1799,7 +1805,7 @@ Kafka topic.</p>
         return pd.read_sql(sql=query, con=session.get_bind(), **options)
 
     @allow_options([&#34;truncate_and_append&#34;])
-    def _write_to_postgres(self, df: pd.DataFrame, **options: Any):
+    def _write_to_postgres(self, df: pd.DataFrame, **options: MutableMapping[str, Any]):
         &#34;&#34;&#34;Write a dataframe to postgres based on the {file_type} of the config_io configuration.
 
         Args:

--- a/docs/mixins.html
+++ b/docs/mixins.html
@@ -41,6 +41,7 @@ __all__ = [
     &#34;resolve_template&#34;,
 ]
 
+import csv
 import glob
 import inspect
 import os
@@ -703,9 +704,9 @@ class WithS3File(WithLocal):
 class WithPostgres:
     &#34;&#34;&#34;Handles I/O operations for Postgres.
 
-     Args:
-        - options:
-            - `truncate_and_append: bool`: If set to `True`, truncates the table and then appends the new rows. Otherwise, it drops the table and recreates it with the new rows.
+    Args:
+       - options:
+           - `truncate_and_append: bool`: If set to `True`, truncates the table and then appends the new rows. Otherwise, it drops the table and recreates it with the new rows.
     &#34;&#34;&#34;
 
     sources_config: Mapping
@@ -800,8 +801,7 @@ class WithPostgres:
             query = query.with_session(session).statement
         return pd.read_sql(sql=query, con=session.get_bind(), **options)
 
-    @allow_options([&#34;truncate_and_append&#34;])
-    def _write_to_postgres(self, df: pd.DataFrame, **options: MutableMapping[str, Any]):
+    def _write_to_postgres(self, df: pd.DataFrame):
         &#34;&#34;&#34;Write a dataframe to postgres based on the {file_type} of the config_io configuration.
 
         Args:
@@ -820,8 +820,7 @@ class WithPostgres:
         schema_name = self.sources_config[&#34;name&#34;]
         model = self._generate_model_from_schema(schema_dict, schema_name)
 
-        if is_truncate_and_append := options.get(&#34;truncate_and_append&#34;, False):
-            options.pop(&#34;truncate_and_append&#34;)
+        is_truncate_and_append = self.options.get(&#34;truncate_and_append&#34;, False)
 
         with session_for(connection_string) as session:
             self._write_to_database(session, model.__tablename__, df, is_truncate_and_append)  # type: ignore
@@ -838,7 +837,18 @@ class WithPostgres:
         &#34;&#34;&#34;
         if is_truncate_and_append:
             session.execute(f&#34;TRUNCATE TABLE {table_name};&#34;)
-            df.to_sql(name=table_name, con=session.get_bind(), if_exists=&#34;append&#34;, index=False)
+
+            # Below is a speedup hack in place of `df.to_csv` with the multipart option. As of today, even with
+            # `method=&#34;multi&#34;`, uploading to Postgres is painfully slow. Hence, we&#39;re resorting to dumping the file as
+            # csv and using Postgres&#39;s CSV import function.
+            # https://stackoverflow.com/questions/2987433/how-to-import-csv-file-data-into-a-postgresql-table
+            with tempfile.NamedTemporaryFile(mode=&#34;r+&#34;) as temp_file:
+                df.to_csv(temp_file, index=False, header=False, sep=&#34;\t&#34;, doublequote=False, escapechar=&#34;\\&#34;, quoting=csv.QUOTE_NONE)
+                temp_file.flush()
+                temp_file.seek(0)
+
+                cur = session.connection().connection.cursor()
+                cur.copy_from(temp_file, table_name, columns=df.columns, null=&#34;&#34;)
         else:
             df.to_sql(name=table_name, con=session.get_bind(), if_exists=&#34;replace&#34;, index=False)
 
@@ -1707,9 +1717,9 @@ Kafka topic.</p>
 <pre><code class="python">class WithPostgres:
     &#34;&#34;&#34;Handles I/O operations for Postgres.
 
-     Args:
-        - options:
-            - `truncate_and_append: bool`: If set to `True`, truncates the table and then appends the new rows. Otherwise, it drops the table and recreates it with the new rows.
+    Args:
+       - options:
+           - `truncate_and_append: bool`: If set to `True`, truncates the table and then appends the new rows. Otherwise, it drops the table and recreates it with the new rows.
     &#34;&#34;&#34;
 
     sources_config: Mapping
@@ -1804,8 +1814,7 @@ Kafka topic.</p>
             query = query.with_session(session).statement
         return pd.read_sql(sql=query, con=session.get_bind(), **options)
 
-    @allow_options([&#34;truncate_and_append&#34;])
-    def _write_to_postgres(self, df: pd.DataFrame, **options: MutableMapping[str, Any]):
+    def _write_to_postgres(self, df: pd.DataFrame):
         &#34;&#34;&#34;Write a dataframe to postgres based on the {file_type} of the config_io configuration.
 
         Args:
@@ -1824,8 +1833,7 @@ Kafka topic.</p>
         schema_name = self.sources_config[&#34;name&#34;]
         model = self._generate_model_from_schema(schema_dict, schema_name)
 
-        if is_truncate_and_append := options.get(&#34;truncate_and_append&#34;, False):
-            options.pop(&#34;truncate_and_append&#34;)
+        is_truncate_and_append = self.options.get(&#34;truncate_and_append&#34;, False)
 
         with session_for(connection_string) as session:
             self._write_to_database(session, model.__tablename__, df, is_truncate_and_append)  # type: ignore
@@ -1842,7 +1850,18 @@ Kafka topic.</p>
         &#34;&#34;&#34;
         if is_truncate_and_append:
             session.execute(f&#34;TRUNCATE TABLE {table_name};&#34;)
-            df.to_sql(name=table_name, con=session.get_bind(), if_exists=&#34;append&#34;, index=False)
+
+            # Below is a speedup hack in place of `df.to_csv` with the multipart option. As of today, even with
+            # `method=&#34;multi&#34;`, uploading to Postgres is painfully slow. Hence, we&#39;re resorting to dumping the file as
+            # csv and using Postgres&#39;s CSV import function.
+            # https://stackoverflow.com/questions/2987433/how-to-import-csv-file-data-into-a-postgresql-table
+            with tempfile.NamedTemporaryFile(mode=&#34;r+&#34;) as temp_file:
+                df.to_csv(temp_file, index=False, header=False, sep=&#34;\t&#34;, doublequote=False, escapechar=&#34;\\&#34;, quoting=csv.QUOTE_NONE)
+                temp_file.flush()
+                temp_file.seek(0)
+
+                cur = session.connection().connection.cursor()
+                cur.copy_from(temp_file, table_name, columns=df.columns, null=&#34;&#34;)
         else:
             df.to_sql(name=table_name, con=session.get_bind(), if_exists=&#34;replace&#34;, index=False)
 

--- a/docs/mixins.html
+++ b/docs/mixins.html
@@ -1687,6 +1687,17 @@ Kafka topic.</p>
 <span>class <span class="ident">WithPostgres</span></span>
 </code></dt>
 <dd>
+<div class="desc">
+    <p>Handles I/O operations for Kafka.</p>
+</div>
+<h2 id="args">Args</h2>
+<ul>
+    <li>options:</li>
+    <ul>
+        <li><code>truncate_and_append: bool</code>: If set to <code>True</code>, truncates the table and then appends the new rows. Otherwise, it drops the table and recreates it with the new rows.</li>
+    </ul>
+</ul>
+
 <div class="desc"><p>Handles I/O operations for Postgres.</p></div>
 <details class="source">
 <summary>

--- a/docs/validations.html
+++ b/docs/validations.html
@@ -159,19 +159,21 @@ def is_in(dataset: str, df: pd.DataFrame, column: str, categorical_values: Set[s
 
 def _validate_all_acceptable_categoricals_are_present(acceptable_categoricals: Set[str], unique_values: Set[str], column: str, dataset: str, df: pd.DataFrame) -&gt; ValidationResult:
     if unique_values == acceptable_categoricals:
-        return ValidationResult(valid=True, message=f&#34;All acceptable categorical values for {dataset}[{column}] are present&#34;, value=0)
-    if unique_values &lt; acceptable_categoricals:
-        return ValidationResult(
+        validation_result = ValidationResult(valid=True, message=f&#34;All acceptable categorical values for {dataset}[{column}] are present&#34;, value=0)
+    elif unique_values &lt; acceptable_categoricals:
+        validation_result = ValidationResult(
             valid=False,
             message=f&#34;Missing categorical values for {dataset}[{column}]: {acceptable_categoricals - unique_values}&#34;,
             value=len(acceptable_categoricals - unique_values),
         )
-    count_invalid = (~df[column].isin(acceptable_categoricals)).sum()
-    return ValidationResult(
-        valid=False,
-        message=f&#34;Values {unique_values - set(acceptable_categoricals)} for {dataset}[{column}] are not acceptable for {count_invalid} cells&#34;,
-        value=count_invalid,
-    )
+    else:
+        count_invalid = (~df[column].isin(acceptable_categoricals)).sum()
+        validation_result = ValidationResult(
+            valid=False,
+            message=f&#34;Values {unique_values - set(acceptable_categoricals)} for {dataset}[{column}] are not acceptable for {count_invalid} cells&#34;,
+            value=count_invalid,
+        )
+    return validation_result
 
 
 def _validate_categoricals_are_a_subset_of_the_acceptable(acceptable_categoricals: Set[str], unique_values: Set[str], column: str, dataset: str, df: pd.DataFrame) -&gt; ValidationResult:

--- a/dynamicio/mixins.py
+++ b/dynamicio/mixins.py
@@ -767,7 +767,7 @@ class WithPostgres:
         return pd.read_sql(sql=query, con=session.get_bind(), **options)
 
     @allow_options(["truncate_and_append"])
-    def _write_to_postgres(self, df: pd.DataFrame, **options: Any):
+    def _write_to_postgres(self, df: pd.DataFrame, **options: MutableMapping[str, Any]):
         """Write a dataframe to postgres based on the {file_type} of the config_io configuration.
 
         Args:

--- a/dynamicio/mixins.py
+++ b/dynamicio/mixins.py
@@ -772,10 +772,6 @@ class WithPostgres:
         Args:
             df: The dataframe to be written
         """
-        # engine = sqlalchemy.create_engine(f"postgresql://{USER}:{PASSWORD}@{HOST}:{PORT}/{DB_NAME}")
-        # conn = engine.connect()
-        # cm_volumes.to_sql("cm_volumes", engine, if_exists="append", index=False)
-
         postgres_config = self.sources_config["postgres"]
         db_user = postgres_config["db_user"]
         db_password = postgres_config["db_password"]

--- a/dynamicio/mixins.py
+++ b/dynamicio/mixins.py
@@ -771,8 +771,7 @@ class WithPostgres:
             query = query.with_session(session).statement
         return pd.read_sql(sql=query, con=session.get_bind(), **options)
 
-    @allow_options(["truncate_and_append"])
-    def _write_to_postgres(self, df: pd.DataFrame, **options: MutableMapping[str, Any]):
+    def _write_to_postgres(self, df: pd.DataFrame):
         """Write a dataframe to postgres based on the {file_type} of the config_io configuration.
 
         Args:
@@ -791,8 +790,7 @@ class WithPostgres:
         schema_name = self.sources_config["name"]
         model = self._generate_model_from_schema(schema_dict, schema_name)
 
-        if is_truncate_and_append := options.get("truncate_and_append", False):
-            options.pop("truncate_and_append")
+        is_truncate_and_append = self.options.get("truncate_and_append", False)
 
         with session_for(connection_string) as session:
             self._write_to_database(session, model.__tablename__, df, is_truncate_and_append)  # type: ignore

--- a/dynamicio/mixins.py
+++ b/dynamicio/mixins.py
@@ -786,7 +786,7 @@ class WithPostgres:
         schema_name = self.sources_config["name"]
         model = self._generate_model_from_schema(schema_dict, schema_name)
 
-        if is_truncate_and_append := options.get("truncate_and_append"):
+        if is_truncate_and_append := options.get("truncate_and_append", False):
             options.pop("truncate_and_append")
 
         with session_for(connection_string) as session:

--- a/dynamicio/mixins.py
+++ b/dynamicio/mixins.py
@@ -672,7 +672,12 @@ class WithS3File(WithLocal):
 
 
 class WithPostgres:
-    """Handles I/O operations for Postgres."""
+    """Handles I/O operations for Postgres.
+
+    Args:
+       - options:
+           - `truncate_and_append: bool`: If set to `True`, truncates the table and then appends the new rows. Otherwise, it drops the table and recreates it with the new rows.
+    """
 
     sources_config: Mapping
     schema: Mapping

--- a/dynamicio/mixins.py
+++ b/dynamicio/mixins.py
@@ -807,7 +807,14 @@ class WithPostgres:
         """
         if is_truncate_and_append:
             session.execute(f"TRUNCATE TABLE {table_name};")
-            df.to_sql(name=table_name, con=session.get_bind(), if_exists="append", index=False)
+            df.to_sql(
+                name=table_name,
+                con=session.get_bind(),
+                if_exists="append",
+                index=False,
+                method="multi",
+                chunksize=250000,
+            )
         else:
             df.to_sql(name=table_name, con=session.get_bind(), if_exists="replace", index=False)
 

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1557,10 +1557,7 @@ class TestPostgresIO:
         )
 
         # When
-        write_config = WritePostgresIO(
-            source_config=postgres_cloud_config,
-            **{"truncate_and_append": True},
-        )
+        write_config = WritePostgresIO(source_config=postgres_cloud_config, truncate_and_append=True)
 
         write_config.write(df)
 

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1544,6 +1544,31 @@ class TestPostgresIO:
         mock__write_to_postgres.assert_called()
 
     @pytest.mark.unit
+    @patch.object(WithPostgres, "_write_to_postgres")
+    def test_write_to_postgres_is_called_with_truncate_and_append_option(self, mock__write_to_postgres, test_df):
+        # Given
+        df = test_df
+        postgres_cloud_config = IOConfig(
+            path_to_source_yaml=(os.path.join(constants.TEST_RESOURCES, "definitions/processed.yaml")),
+            env_identifier="CLOUD",
+            dynamic_vars=constants,
+        ).get(
+            source_key="WRITE_TO_PG_PARQUET",
+        )
+
+        # When
+        write_config = WritePostgresIO(
+            source_config=postgres_cloud_config,
+            **{"truncate_and_append": True},
+        )
+
+        write_config.write(df)
+
+        # Then
+        mock__write_to_postgres.assert_called_with(test_df)
+        assert "truncate_and_append" in write_config.options
+
+    @pytest.mark.unit
     @patch.object(WithPostgres, "_read_from_postgres")
     def test_read_from_postgres_by_implicitly_generating_datamodel_from_schema(self, mock__read_from_postgres, test_df):
         # Given


### PR DESCRIPTION
## Overview

There is a use case that I want to implement when migrating some legacy code, but I noticed that `dynamicio` does not currently support this.

When writing to Postgres, I would like to truncate and append to a table instead of dropping and replacing it. The latter is the current default behaviour.

Dropping the table may be undesirable  when the table has views derived from it in the database.

Note: Using `df.to_sql` even with the `method="multi"` enabled is painfully slow and not much can be done about it. The fastest way to upload something into Postgres is by using its `COPY FROM ... CSV` function. This is what ended up being implemented.

I've run RC4 in my a dev pipeline, I can confirm that that database has been populated correctly.

## Key Changes

* Added a `truncate_and_append` option to `_write_to_postgres`

## Impact

* The impact is incremental. No existing functionality is broken, and the change is backwards compatible

## Checklist

The following won't apply in all cases - mark `N/A` next to point if not needed.

- [x] Appropriate unit tests added/updated
- [x] Module, function, class docstrings updated
- [x] Comments added to PR where necessary
- [x] Interface documentation updated
- [x] Semantic commits used for this PR, so that a CHANGELOG can be generated from them (don't delete your local branch! when tagging a new release from master)

## Optional Below:

- [x] Screenshots of actual interactions with live resources. 
- [ ] Performance stats/graphs.

## Release-Steps

- [ ] Merge PR
- [ ] Release new tag
