### PR TITLE
fix: Address sql_query marked as false input warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ generate-docs:
 
 build-locally:
 	@${VENV_BIN_PATH}/pip install --upgrade build
-	@BUILD_VERSION=3.1.1 ${VENV_BIN_PATH}/python setup.py sdist bdist_wheel # Add a <some_version>, e.g. 0.2.3
+	@BUILD_VERSION=4.1.3 ${VENV_BIN_PATH}/python setup.py sdist bdist_wheel # Add a <some_version>, e.g. 0.2.3
 
 upload-package:
 	@${VENV_BIN_PATH}/pip install --upgrade twine

--- a/dynamicio/mixins.py
+++ b/dynamicio/mixins.py
@@ -706,9 +706,7 @@ class WithPostgres:
 
         connection_string = f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
 
-        sql_query = self.options.get("sql_query")
-
-        query = None
+        sql_query = self.options.pop("sql_query", None)
 
         if "schema" not in self.sources_config:
             schema_dict = self.schema
@@ -765,9 +763,6 @@ class WithPostgres:
         Returns:
             DataFrame
         """
-        if options.get("model"):
-            options.pop("model")
-
         if isinstance(query, Query):
             query = query.with_session(session).statement
         return pd.read_sql(sql=query, con=session.get_bind(), **options)

--- a/dynamicio/mixins.py
+++ b/dynamicio/mixins.py
@@ -720,6 +720,7 @@ class WithPostgres:
         if sql_query:
             query = sql_query
 
+        logger.info(f"[postgres] Started downloading table: {schema_name} from: {db_host}:{db_name}")
         with session_for(connection_string) as session:
             return self._read_database(session, query, **self.options)
 
@@ -788,6 +789,7 @@ class WithPostgres:
 
         is_truncate_and_append = self.options.get("truncate_and_append", False)
 
+        logger.info(f"[postgres] Started downloading table: {schema_name} from: {db_host}:{db_name}")
         with session_for(connection_string) as session:
             self._write_to_database(session, model.__tablename__, df, is_truncate_and_append)  # type: ignore
 

--- a/tests/resources/definitions/input.yaml
+++ b/tests/resources/definitions/input.yaml
@@ -173,6 +173,20 @@ READ_FROM_POSTGRES:
   schema:
     file_path: "[[ TEST_RESOURCES ]]/schemas/pg.yaml"
 
+READ_FROM_POSTGRES_WITH_QUERY_IN_OPTIONS:
+  CLOUD:
+    type: "postgres"
+    postgres:
+      db_host: "[[ DB_HOST ]]"
+      db_port: "[[ DB_PORT ]]"
+      db_name: "[[ DB_NAME ]]"
+      db_user: "[[ DB_USER ]]"
+      db_password: "[[ DB_PASS ]]"
+    options:
+      sql_query: "SELECT * FROM table_name_from_yaml_options"
+  schema:
+    file_path: "[[ TEST_RESOURCES ]]/schemas/pg.yaml"
+
 READ_FROM_KAFKA:
   LOCAL:
     type: "local"

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1594,7 +1594,23 @@ class TestPostgresIO:
         ReadPostgresIO(source_config=postgres_cloud_config, sql_query="SELECT * FROM example").read()
 
         # Then
-        mock__read_database.assert_called_with(ANY, "SELECT * FROM example", sql_query="SELECT * FROM example")
+        mock__read_database.assert_called_with(ANY, "SELECT * FROM example")
+
+    @pytest.mark.unit
+    @patch.object(WithPostgres, "_read_database")
+    def test_read_from_postgres_with_query_in_options(self, mock__read_database):
+        # Given
+        postgres_cloud_config = IOConfig(
+            path_to_source_yaml=(os.path.join(constants.TEST_RESOURCES, "definitions/input.yaml")),
+            env_identifier="CLOUD",
+            dynamic_vars=constants,
+        ).get(source_key="READ_FROM_POSTGRES_WITH_QUERY_IN_OPTIONS")
+
+        # When
+        ReadPostgresIO(source_config=postgres_cloud_config).read()
+
+        # Then
+        mock__read_database.assert_called_with(ANY, "SELECT * FROM table_name_from_yaml_options")
 
     @pytest.mark.unit
     @patch.object(pd, "read_sql")


### PR DESCRIPTION
## Overview

The `sql_query` option was not being cleared out prior  making requests to a postgres instance. This PR addresses this issue. 

## Key Changes

* `sql_query` option is now popped prior to calling `pd.read_sql()`
* Removed redundant popping of the `model` option. 

## Checklist

The following won't apply in all cases - mark `N/A` next to point if not needed.

- [x] Appropriate unit tests added/updated
- [x] Module, function, class docstrings updated
- [x] Comments added to PR where necessary
- [x] Interface documentation updated
- [x] Semantic commits used for this PR, so that a CHANGELOG can be generated from them (don't delete your local branch! when tagging a new release from master)

## Release-Steps

- [x] Merge PR
- [x] Release new tag --> v4.1.3
