### PR TITLE
feat: Introduce 'df' cached_property

### DIFF
--- a/dynamicio/core.py
+++ b/dynamicio/core.py
@@ -13,7 +13,7 @@ import pandas as pd  # type: ignore
 from magic_logger import logger
 
 from dynamicio import validations
-from dynamicio.errors import CASTING_WARNING_MSG, NOTICE_MSG, ColumnsDataTypeError, MissingSchemaDefinition, SchemaNotFoundError, SchemaValidationError
+from dynamicio.errors import CASTING_WARNING_MSG, NOTICE_MSG, ColumnsDataTypeError, MissingSchemaDefinition, SchemaNotFoundError, SchemaValidationError  # noqa: I101
 from dynamicio.metrics import get_metric
 
 SCHEMA_FROM_FILE = {"schema": object()}

--- a/dynamicio/core.py
+++ b/dynamicio/core.py
@@ -13,7 +13,7 @@ import pandas as pd  # type: ignore
 from magic_logger import logger
 
 from dynamicio import validations
-from dynamicio.errors import CASTING_WARNING_MSG, ColumnsDataTypeError, MissingSchemaDefinition, NOTICE_MSG, SchemaNotFoundError, SchemaValidationError
+from dynamicio.errors import CASTING_WARNING_MSG, NOTICE_MSG, ColumnsDataTypeError, MissingSchemaDefinition, SchemaNotFoundError, SchemaValidationError
 from dynamicio.metrics import get_metric
 
 SCHEMA_FROM_FILE = {"schema": object()}
@@ -111,7 +111,7 @@ class DynamicDataIO:
         return self.read()
 
     def clear_cache(self) -> None:
-        """ Resets self.df cached_property by deleting it. """
+        """Resets self.df cached_property by deleting it."""
         if "df" in self.__dict__:
             del self.df
 

--- a/dynamicio/core.py
+++ b/dynamicio/core.py
@@ -6,6 +6,7 @@ import asyncio
 import inspect
 import re
 from concurrent.futures import ThreadPoolExecutor
+from functools import cached_property
 from typing import Any, Mapping, MutableMapping, Optional
 
 import pandas as pd  # type: ignore
@@ -99,6 +100,20 @@ class DynamicDataIO:
         """
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(pool, self.read)
+
+    @cached_property
+    def df(self) -> pd.DataFrame:
+        """Uses read() and caches it. Useful for lazy-loading.
+
+        Returns:
+            A pandas dataframe or an iterable.
+        """
+        return self.read()
+
+    def clear_cache(self) -> None:
+        """ Resets self.df cached_property by deleting it. """
+        if "df" in self.__dict__:
+            del self.df
 
     def read(self) -> pd.DataFrame:
         """Reads data source and returns a schema validated dataframe (by means of _apply_schema).

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1041,12 +1041,11 @@ class TestAsyncCoreIO:
         ).get(source_key="READ_FROM_S3_CSV")
 
         # Dataframe should be cached once and read function should not be called again
-        io = ReadS3CsvIO(source_config=s3_csv_local_config)
-        _ = io.df
-        _ = io.df
-        _ = io.df
+        s3_csv_io = ReadS3CsvIO(source_config=s3_csv_local_config)
+        _ = s3_csv_io.df
+        _ = s3_csv_io.df
+        _ = s3_csv_io.df
         assert mock_read.call_count == 1
-
 
     @pytest.mark.unit
     @patch.object(dynamicio.core.DynamicDataIO, "read")
@@ -1059,15 +1058,15 @@ class TestAsyncCoreIO:
         ).get(source_key="READ_FROM_S3_CSV")
 
         # Dataframe should be read once initially and twice after clearing cache
-        io = ReadS3CsvIO(source_config=s3_csv_local_config)
-        _ = io.df
-        _ = io.df
-        io.clear_cache()
-        _ = io.df
-        _ = io.df
-        io.clear_cache()
-        _ = io.df
-        _ = io.df
+        s3_csv_io = ReadS3CsvIO(source_config=s3_csv_local_config)
+        _ = s3_csv_io.df
+        _ = s3_csv_io.df
+        s3_csv_io.clear_cache()
+        _ = s3_csv_io.df
+        _ = s3_csv_io.df
+        s3_csv_io.clear_cache()
+        _ = s3_csv_io.df
+        _ = s3_csv_io.df
         assert mock_read.call_count == 3
 
     @pytest.mark.unit
@@ -1080,9 +1079,9 @@ class TestAsyncCoreIO:
         ).get(source_key="READ_FROM_S3_CSV")
 
         # Dataframe should be read once initially and twice after clearing cache
-        io = ReadS3CsvIO(source_config=s3_csv_local_config)
-        df = io.df
+        s3_csv_io = ReadS3CsvIO(source_config=s3_csv_local_config)
+        df = s3_csv_io.df
 
         df["new_column"] = True
 
-        assert sum(io.df["new_column"] == True) == df.shape[0]
+        assert sum(s3_csv_io.df["new_column"]) == df.shape[0]


### PR DESCRIPTION
## Overview

Cached property using python's `@cached_property` decorator. Allows for more elegant code when lazy-loading/ memory limitations are important.

## Key Changes

* Added `df` property to the `DynamicDataIO` class

## Checklist

- [x] Appropriate unit tests added/updated
- [x] Module, function, class docstrings updated
- [ ] Interface documentation updated
- [ ] Semantic commits used for this PR, so that a CHANGELOG can be generated from them (don't delete your local branch! when tagging a new release from master)

## Release-Steps

- [ ] Merge PR
- [ ] Release new tag
