### PR TITLE
refactor: Introduce Pydantic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ jobs:
       - run:
           name: "Code Quality Check"
           command: |
-            black dynamicio
-            black tests
+            black --check dynamicio
+            black --check tests
             flake8 --verbose dynamicio
             flake8 --verbose tests
             pylint -v dynamicio

--- a/.flake8
+++ b/.flake8
@@ -15,5 +15,7 @@ max-line-length = 185
 max-complexity = 18
 select = B,C,E,F,W,T,I,B
 
+ban-relative-imports = true
+
 import-order-style = edited
 application-import-names = dynamicio, tests

--- a/.pylintrc
+++ b/.pylintrc
@@ -456,7 +456,7 @@ max-returns=6
 max-statements=50
 
 # Minimum number of public methods for a class (see R0903).
-min-public-methods=2
+min-public-methods=0
 
 
 [STRING]

--- a/demo/tests/test_pipeline.py
+++ b/demo/tests/test_pipeline.py
@@ -32,12 +32,24 @@ class TestPipeline:
 
         # Then
         try:
-            assert expected_staged_foo_df.equals(pd.read_parquet(raw_config.get(source_key="STAGED_FOO")["local"]["file_path"]))
-            assert expected_staged_bar_df.equals(pd.read_parquet(raw_config.get(source_key="STAGED_BAR")["local"]["file_path"]))
-            assert expected_final_foo_df.equals(pd.read_parquet(processed_config.get(source_key="FINAL_FOO")["local"]["file_path"]))
-            assert expected_final_bar_df.equals(pd.read_parquet(processed_config.get(source_key="FINAL_BAR")["local"]["file_path"]))
+            pd.testing.assert_frame_equal(
+                expected_staged_foo_df,
+                pd.read_parquet(raw_config.get(source_key="STAGED_FOO").local.file_path)
+            )
+            pd.testing.assert_frame_equal(
+                expected_staged_bar_df,
+                pd.read_parquet(raw_config.get(source_key="STAGED_BAR").local.file_path)
+            )
+            pd.testing.assert_frame_equal(
+                expected_final_foo_df,
+                pd.read_parquet(processed_config.get(source_key="FINAL_FOO").local.file_path)
+            )
+            pd.testing.assert_frame_equal(
+                expected_final_bar_df,
+                pd.read_parquet(processed_config.get(source_key="FINAL_BAR").local.file_path)
+            )
         finally:
-            os.remove(raw_config.get(source_key="STAGED_FOO")["local"]["file_path"])
-            os.remove(raw_config.get(source_key="STAGED_BAR")["local"]["file_path"])
-            os.remove(processed_config.get(source_key="FINAL_FOO")["local"]["file_path"])
-            os.remove(processed_config.get(source_key="FINAL_BAR")["local"]["file_path"])
+            os.remove(raw_config.get(source_key="STAGED_FOO").local.file_path)
+            os.remove(raw_config.get(source_key="STAGED_BAR").local.file_path)
+            os.remove(processed_config.get(source_key="FINAL_FOO").local.file_path)
+            os.remove(processed_config.get(source_key="FINAL_BAR").local.file_path)

--- a/dynamicio/__init__.py
+++ b/dynamicio/__init__.py
@@ -14,7 +14,7 @@ from dynamicio.mixins import WithKafka, WithLocal, WithLocalBatch, WithPostgres,
 os.environ["LC_CTYPE"] = "en_US.UTF"  # Set your locale to a unicode-compatible one
 
 
-class UnifiedIO(WithS3File, WithS3PathPrefix, WithLocalBatch, WithLocal, WithKafka, WithPostgres, DynamicDataIO):
+class UnifiedIO(WithS3File, WithS3PathPrefix, WithLocalBatch, WithLocal, WithKafka, WithPostgres, DynamicDataIO):  # type: ignore
     """A unified io composed of dynamicio.mixins."""
 
 

--- a/dynamicio/config/__init__.py
+++ b/dynamicio/config/__init__.py
@@ -1,0 +1,4 @@
+"""Dynamicio config file handling routines."""
+
+from dynamicio.config import pydantic
+from dynamicio.config.io_config import IOConfig

--- a/dynamicio/config/pydantic/__init__.py
+++ b/dynamicio/config/pydantic/__init__.py
@@ -1,0 +1,13 @@
+"""Pydantic config models."""
+
+from dynamicio.config.pydantic.config import BindingsYaml
+from dynamicio.config.pydantic.io_resources import (
+    IOEnvironment,
+    KafkaDataEnvironment,
+    LocalBatchDataEnvironment,
+    LocalDataEnvironment,
+    PostgresDataEnvironment,
+    S3DataEnvironment,
+    S3PathPrefixEnvironment,
+)
+from dynamicio.config.pydantic.table_schema import DataframeSchema

--- a/dynamicio/config/pydantic/config.py
+++ b/dynamicio/config/pydantic/config.py
@@ -1,0 +1,38 @@
+# pylint: disable=no-member, no-self-argument, unused-argument
+"""Pydantic schema for YAML files"""
+
+from typing import Mapping, MutableMapping
+
+import pydantic
+
+import dynamicio.config.pydantic.io_resources as env_spec
+
+
+class BindingsYaml(pydantic.BaseModel):
+    """Class controlling structure of the top-level IOConfig yaml file.
+
+    The top-level config is a dictionary of <binding_name> -> <env_name>
+    """
+
+    bindings: Mapping[str, env_spec.IOBinding]
+
+    @pydantic.validator("bindings", pre=True)
+    def _validate_bindings(cls, value: Mapping):
+        if not isinstance(value, Mapping):
+            raise ValueError(f"Bindings must be a mapping. (got {value!r} instead).")
+        # Tell each binding its name
+        for (name, sub_config) in value.items():
+            if not isinstance(sub_config, MutableMapping):
+                raise ValueError(f"Each element for the name binding must be a dict. (got {sub_config!r} instead)")
+            sub_config["__binding_name__"] = name
+        return value
+
+    def update_config_refs(self) -> "BindingsYaml":
+        """Updates dynamic parts of the config:
+        - Configure _parent for all `IOEnvironment`s
+        - Replace all IOSchemaRef with actual schema objects
+        """
+        for binding in self.bindings.values():
+            for io_env in binding.environments.values():
+                io_env.set_parent(binding)
+        return self

--- a/dynamicio/config/pydantic/io_resources.py
+++ b/dynamicio/config/pydantic/io_resources.py
@@ -1,0 +1,220 @@
+# pylint: disable=no-member, no-self-argument, unused-argument
+
+"""This module contains pylint models for physical data sources (places the bytes are being read from)"""
+
+import enum
+import posixpath
+from typing import Mapping, Optional, Union
+
+import pydantic
+
+import dynamicio.config.pydantic.table_schema as table_spec
+
+
+@enum.unique
+class DataBackendType(str, enum.Enum):
+    """Input file types"""
+
+    # pylint: disable=invalid-name
+    local = "local"
+    local_batch = "local_batch"
+    s3 = "s3"  # is there a difference between 's3' and 's3_file' ?
+    s3_file = "s3_file"
+    s3_path_prefix = "s3_path_prefix"
+    postgres = "postgres"
+    athena = "athena"
+    kafka = "kafka"
+
+
+@enum.unique
+class FileType(str, enum.Enum):
+    """List of supported file formats."""
+
+    # pylint: disable=invalid-name
+    parquet = "parquet"
+    csv = "csv"
+    json = "json"
+    hdf = "hdf"
+
+
+class IOBinding(pydantic.BaseModel):
+    """A binding for a single i/o object"""
+
+    name: str = pydantic.Field(alias="__binding_name__")
+    environments: Mapping[str, "IOEnvironment"]
+    dynamicio_schema: Union[table_spec.DataframeSchema, None] = pydantic.Field(default=None, alias="schema")
+
+    def get_binding_for_environment(self, environment: str) -> "IOEnvironment":
+        """Fetch the IOEnvironment spec for the name provided."""
+        return self.environments[environment]
+
+    @pydantic.validator("environments", pre=True, always=True)
+    def pick_correct_env_cls(cls, value, values, config, field):
+        """This pre-validator picks an appropriate IOEnvironment subclass for the `data_backend_type`"""
+        if not isinstance(value, Mapping):
+            raise ValueError(f"Environments input should be a dict. Got {value!r} instead.")
+        config_cls_overrides = {
+            DataBackendType.local: LocalDataEnvironment,
+            DataBackendType.local_batch: LocalBatchDataEnvironment,
+            DataBackendType.s3: S3DataEnvironment,
+            DataBackendType.s3_file: S3DataEnvironment,
+            DataBackendType.s3_path_prefix: S3PathPrefixEnvironment,
+            DataBackendType.kafka: KafkaDataEnvironment,
+            DataBackendType.postgres: PostgresDataEnvironment,
+        }
+        out_dict = {}
+        for (env_name, env_data) in value.items():
+            base_obj: IOEnvironment = field.type_(**env_data)
+            override_cls = config_cls_overrides.get(base_obj.data_backend_type)
+            if override_cls:
+                use_obj = override_cls(**env_data)
+            else:
+                use_obj = base_obj
+            out_dict[env_name] = use_obj
+        return out_dict
+
+    @pydantic.root_validator(pre=True)
+    def _preprocess_raw_config(cls, values):
+        if not isinstance(values, Mapping):
+            raise ValueError(f"IOBinding must be a dict at the top level. (got {values!r} instead)")
+        remapped_value = {"environments": {}}
+        for (key, value) in values.items():
+            if key in ("__binding_name__", "schema"):
+                # Passthrough params
+                remapped_value[key] = value
+            else:
+                # Assuming an environment config
+                remapped_value["environments"][key] = value
+        return remapped_value
+
+
+class IOEnvironment(pydantic.BaseModel):
+    """A section specifiing an data source backed by a particular data backend"""
+
+    _parent: Optional[IOBinding] = None  # noqa: F821
+    options: Mapping = pydantic.Field(default_factory=dict)
+    data_backend_type: DataBackendType = pydantic.Field(alias="type", const=None)
+
+    class Config:
+        """Additional pydantic configuration for the model."""
+
+        underscore_attrs_are_private = True
+
+    @property
+    def dynamicio_schema(self) -> Union[table_spec.DataframeSchema, None]:
+        """Returns tabular data structure definition for the data source (if available)"""
+        if not self._parent:
+            raise Exception("Parent field is not set.")
+        return self._parent.dynamicio_schema
+
+    def set_parent(self, parent: IOBinding):  # noqa: F821
+        """Helper method to set parent config object."""
+        assert self._parent is None
+        self._parent = parent
+
+
+class LocalDataSubSection(pydantic.BaseModel):
+    """Config section for local data provider"""
+
+    file_path: str
+    file_type: FileType
+
+
+class LocalDataEnvironment(IOEnvironment):
+    """The data is provided by local storage"""
+
+    local: LocalDataSubSection
+
+
+class LocalBatchDataSubSection(pydantic.BaseModel):
+    """Config section for local batch data (multiple input files)"""
+
+    path_prefix: str
+    file_type: FileType
+
+
+class LocalBatchDataEnvironment(IOEnvironment):
+    """Parent section for local batch (multiple files) config."""
+
+    local: LocalBatchDataSubSection
+
+
+class S3DataSubSection(pydantic.BaseModel):
+    """Config section for S3 data source"""
+
+    file_path: str
+    file_type: FileType
+    bucket: str
+
+
+class S3DataEnvironment(IOEnvironment):
+    """Parent section for s3 data source config"""
+
+    s3: S3DataSubSection
+
+
+class S3PathPrefixSubSection(pydantic.BaseModel):
+    """Config section for s3 prefix data source (multiple s3 objects)"""
+
+    path_prefix: str
+    file_type: FileType
+    bucket: str
+
+    @pydantic.root_validator(pre=True)
+    def support_legacy_config_path_prefix(cls, values):
+        """
+        This validator implements support for legacy config format where the
+        bucket & path_prefix path could've been passed as a single param in 'bucket' field.
+
+        E.g.
+            bucket: "[[ MOCK_BUCKET ]]/data/input/{file_name_to_replace}.hdf"
+        """
+        bucket = values.get("bucket")
+        path_prefix = values.get("path_prefix")
+        if (bucket and isinstance(bucket, str) and posixpath.sep in bucket) and (not path_prefix):
+            (new_bucket, new_path_prefix) = bucket.split(posixpath.sep, 1)
+            values.update(
+                {
+                    "bucket": new_bucket,
+                    "path_prefix": new_path_prefix,
+                }
+            )
+        return values
+
+
+class S3PathPrefixEnvironment(IOEnvironment):
+    """Parent section for the multi-object s3 data source"""
+
+    s3: S3PathPrefixSubSection
+
+
+class KafkaDataSubSection(pydantic.BaseModel):
+    """Kafka configuration section."""
+
+    kafka_server: str
+    kafka_topic: str
+
+
+class KafkaDataEnvironment(IOEnvironment):
+    """Parent section for kafka data source config"""
+
+    kafka: KafkaDataSubSection
+
+
+class PostgresDataSubSection(pydantic.BaseModel):
+    """Postgres data source configuration."""
+
+    db_host: str
+    db_port: str
+    db_name: str
+    db_user: str
+    db_password: str
+
+
+class PostgresDataEnvironment(IOEnvironment):
+    """Parent section for postgres data source."""
+
+    postgres: PostgresDataSubSection
+
+
+IOBinding.update_forward_refs()

--- a/dynamicio/config/pydantic/table_schema.py
+++ b/dynamicio/config/pydantic/table_schema.py
@@ -1,0 +1,134 @@
+# pylint: disable=no-member, no-self-argument, unused-argument
+
+"""This module defines Config schema for data source (pandas dataframe)"""
+
+import enum
+from typing import Mapping, Sequence, Union
+
+import pydantic
+
+
+@enum.unique
+class MetricsName(str, enum.Enum):
+    """The list of valid metrics names."""
+
+    # pylint: disable=invalid-name
+    min = "Min"
+    max = "Max"
+    mean = "Mean"
+    stddev = "Std"
+    variance = "Variance"
+    counts = "Counts"
+    counts_per_label = "CountsPerLabel"
+    unique_counts = "UniqueCounts"
+
+
+@enum.unique
+class ColumnType(str, enum.Enum):
+    """The list of valid column types."""
+
+    # pylint: disable=invalid-name
+    object = "object"
+    string = "string"
+    array = "array"
+    number = "number"
+
+    float = "float"
+    float32 = "float32"
+    float64 = "float64"
+    double = "double"
+
+    int = "int"
+    integer = "integer"
+
+    int8 = "int8"
+    int32 = "int32"
+    int64 = "int64"
+
+    Int8 = "Int8"
+    Int32 = "Int32"
+    Int64 = "Int64"
+
+    uint8 = "uint8"
+    uint32 = "uint32"
+    uint64 = "uint64"
+
+    bool = "bool"
+    boolean = "boolean"
+
+    datetime64_ns = "datetime64[ns]"
+    datetime64_ns_utc = "datetime64[ns,UTC]"
+    datetime64_ms = "datetime64[ms]"
+
+    timedelta64_ns = "timedelta64[ns]"
+
+
+class ColumnValidationBase(pydantic.BaseModel):
+    """A single column validator."""
+
+    name: str
+    apply: bool
+    options: Mapping[str, object]
+
+
+ColumnValidationType = Union[ColumnValidationBase, ColumnValidationBase]
+
+
+class SchemaColumn(pydantic.BaseModel):
+    """Definition os a single data source column."""
+
+    name: str
+    data_type: ColumnType = pydantic.Field(alias="type")
+    validations: Sequence[ColumnValidationType] = pydantic.Field(default_factory=list)
+    metrics: Sequence[MetricsName] = ()
+
+    @pydantic.validator("validations", pre=True)
+    def remap_validations(cls, field):
+        """Remap the yaml structure of {validation_type: <params>} to a list with validation_type as a key"""
+        if not isinstance(field, dict):
+            raise ValueError(f"{field!r} should be a dict")
+        out = []
+        for (key, params) in field.items():
+            new_el = params.copy()
+            new_el.update({"name": key})
+            out.append(new_el)
+        return out
+
+    @pydantic.validator("metrics", pre=True, always=True)
+    def validate_metrics(cls, field):
+        """Remap any false-ish `metrics` value to an empty list."""
+        if field:
+            out = field
+        else:
+            out = []
+        return out
+
+
+class DataframeSchema(pydantic.BaseModel):
+    """Pydantic model describing the tabular data provided by the data source."""
+
+    name: str
+    columns: Mapping[str, SchemaColumn]
+
+    @pydantic.validator("columns", pre=True)
+    def supply_column_names(cls, field):
+        """Tell each column its name (the key it is listed under)"""
+        if not isinstance(field, Mapping):
+            raise ValueError(f"{field!r} shoudl be a dict.")
+
+        return {col_name: {**{"name": col_name}, **col_data} for (col_name, col_data) in field.items()}
+
+    @property
+    def validations(self) -> Mapping[str, Sequence[ColumnValidationType]]:
+        """A short-hand property to access the validators for each column."""
+        return {col_name: col.validations for (col_name, col) in self.columns.items()}
+
+    @property
+    def metrics(self) -> Mapping[str, Sequence[MetricsName]]:
+        """A short-hand property to access the metrics for each column."""
+        return {col_name: col.metrics for (col_name, col) in self.columns.items()}
+
+    @property
+    def column_names(self) -> Sequence[str]:
+        """Property providing the list of all column names."""
+        return tuple(self.columns.keys())

--- a/dynamicio/config/pydantic/table_schema.py
+++ b/dynamicio/config/pydantic/table_schema.py
@@ -71,15 +71,12 @@ class ColumnValidationBase(pydantic.BaseModel):
     options: Mapping[str, object]
 
 
-ColumnValidationType = Union[ColumnValidationBase, ColumnValidationBase]
-
-
 class SchemaColumn(pydantic.BaseModel):
     """Definition os a single data source column."""
 
     name: str
     data_type: ColumnType = pydantic.Field(alias="type")
-    validations: Sequence[ColumnValidationType] = pydantic.Field(default_factory=list)
+    validations: Sequence[ColumnValidationBase] = pydantic.Field(default_factory=list)
     metrics: Sequence[MetricsName] = ()
 
     @pydantic.validator("validations", pre=True)

--- a/dynamicio/config/pydantic/table_schema.py
+++ b/dynamicio/config/pydantic/table_schema.py
@@ -3,7 +3,7 @@
 """This module defines Config schema for data source (pandas dataframe)"""
 
 import enum
-from typing import Mapping, Sequence, Union
+from typing import Mapping, Sequence
 
 import pydantic
 
@@ -116,7 +116,7 @@ class DataframeSchema(pydantic.BaseModel):
         return {col_name: {**{"name": col_name}, **col_data} for (col_name, col_data) in field.items()}
 
     @property
-    def validations(self) -> Mapping[str, Sequence[ColumnValidationType]]:
+    def validations(self) -> Mapping[str, Sequence[ColumnValidationBase]]:
         """A short-hand property to access the validators for each column."""
         return {col_name: col.validations for (col_name, col) in self.columns.items()}
 

--- a/dynamicio/core.py
+++ b/dynamicio/core.py
@@ -9,9 +9,11 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Mapping, MutableMapping, Optional
 
 import pandas as pd  # type: ignore
+import pydantic
 from magic_logger import logger
 
 from dynamicio import validations
+from dynamicio.config.pydantic import DataframeSchema, IOEnvironment
 from dynamicio.errors import CASTING_WARNING_MSG, ColumnsDataTypeError, MissingSchemaDefinition, NOTICE_MSG, SchemaNotFoundError, SchemaValidationError
 from dynamicio.metrics import get_metric
 
@@ -37,11 +39,12 @@ class DynamicDataIO:
        >>> my_dataset_df = my_dataset_io.read()
     """
 
-    schema: Mapping
+    schema: DataframeSchema
+    sources_config: IOEnvironment
 
     def __init__(
         self,
-        source_config: Mapping,
+        source_config: IOEnvironment,
         apply_schema_validations: bool = False,
         log_schema_metrics: bool = False,
         show_casting_warnings: bool = False,
@@ -64,20 +67,57 @@ class DynamicDataIO:
         self.apply_schema_validations = apply_schema_validations
         self.log_schema_metrics = log_schema_metrics
         self.show_casting_warnings = show_casting_warnings
-        self.options = self._get_options(options, source_config.get("options"))
-        source_name = self.sources_config.get("type")
+        self.options = self._get_options(options, source_config.options)
+        source_name = self.sources_config.data_backend_type
         if self.schema is SCHEMA_FROM_FILE:
-            try:
-                self.schema = self.sources_config["schema"]
-                self.name = self.sources_config["name"].upper()
-                self.schema_validations = self.sources_config["validations"]
-                self.schema_metrics = self.sources_config["metrics"]
-            except KeyError as _error:
-                raise SchemaNotFoundError() from _error
+            active_schema = self.sources_config.dynamicio_schema
+        else:
+            active_schema = self._schema_from_obj(self)
+
+        if not active_schema:
+            raise SchemaNotFoundError()
+
+        assert isinstance(active_schema, DataframeSchema)
+        self.schema = active_schema
+        self.name = self.schema.name.upper()
+        self.schema_validations = self.schema.validations
+        self.schema_metrics = self.schema.metrics
 
         assert hasattr(self, f"_read_from_{source_name}") or hasattr(
             self, f"_write_to_{source_name}"
         ), f"No method '_read_from_{source_name}' or '_write_to_{source_name}'. Have you registered a mixin for {source_name}?"
+
+    @staticmethod
+    def _schema_from_obj(target) -> DataframeSchema:
+        """Construct `DataframeSchema` from an object.
+
+        The object:
+            - MUST have `schema` attribute that is a dictionary specifying columns and datatypes
+            - CAN have `schema_validations` and `schema_metrics` attributes
+        """
+        col_info = {}
+        for (col_name, dtype) in target.schema.items():
+            col_validations = {}
+            col_metrics = []
+            try:
+                col_validations = target.schema_validations[col_name]
+            except (KeyError, AttributeError):
+                pass
+            try:
+                col_metrics = target.schema_metrics[col_name]
+            except (KeyError, AttributeError):
+                pass
+            col_info[col_name] = {
+                "type": dtype,
+                "validations": col_validations,
+                "metrics": col_metrics,
+            }
+        try:
+            out = DataframeSchema(name=target.name, columns=col_info)
+        except pydantic.ValidationError:
+            logger.exception(f"Error parsing {target.name=!r} {col_info=!r}")
+            raise
+        return out
 
     def __init_subclass__(cls):
         """Ensure that all subclasses have a `schema` attribute and a `validate` method.
@@ -106,7 +146,7 @@ class DynamicDataIO:
         Returns:
             A pandas dataframe or an iterable.
         """
-        source_name = self.sources_config.get("type")
+        source_name = self.sources_config.data_backend_type
         df = getattr(self, f"_read_from_{source_name}")()
 
         df = self._apply_schema(df)
@@ -132,9 +172,9 @@ class DynamicDataIO:
         Args:
             df: The data to be written
         """
-        source_name = self.sources_config.get("type")
-        if set(df.columns) != set(self.schema.keys()):  # pylint: disable=E1101
-            columns = [column for column in df.columns.to_list() if column in self.schema.keys()]
+        source_name = self.sources_config.data_backend_type
+        if set(df.columns) != self.schema.column_names:  # pylint: disable=E1101
+            columns = [column for column in df.columns.to_list() if column in self.schema.column_names]
             df = df[columns]
 
         if self.apply_schema_validations:
@@ -160,16 +200,18 @@ class DynamicDataIO:
                 the exception object is a `List[str]`, where each element is the name of a
                 validation that failed.
         """
-        if not hasattr(self, "schema_validations"):
-            raise MissingSchemaDefinition(self.__class__)
 
         failed_validations = {}
         for column in self.schema_validations.keys():
-            for validation in self.schema_validations[column].keys():
-                if self.schema_validations[column][validation]["apply"] is True:
-                    validation_result = getattr(validations, validation)(self.name, df, column, **self.schema_validations[column][validation]["options"])
+            col_validations = self.schema_validations[column]
+            if not col_validations:
+                raise MissingSchemaDefinition(f"{self.__class__} is missing validations for {column} column")
+            for validation in col_validations:
+                if validation.apply:
+                    validator = validations.ALL_VALIDATORS[validation.name]
+                    validation_result = validator(self.name, df, column, **validation.options)
                     if not validation_result.valid:
-                        failed_validations[validation] = validation_result.message
+                        failed_validations[validation.name] = validation_result.message
 
         if len(failed_validations) > 0:
             raise SchemaValidationError(failed_validations)
@@ -185,12 +227,15 @@ class DynamicDataIO:
         Returns:
              self (to allow for method chaining).
         """
-        if not hasattr(self, "schema_metrics"):
-            raise MissingSchemaDefinition(self.__class__)
 
+        any_metrices = False
         for column in self.schema_metrics.keys():
             for metric in self.schema_metrics[column]:
+                any_metrices = True
                 get_metric(metric)(self.name, df, column)()  # type: ignore
+
+        if not any_metrices:
+            raise MissingSchemaDefinition(self.__class__)
 
         return self
 
@@ -241,7 +286,9 @@ class DynamicDataIO:
         """
         dtypes = df.dtypes
 
-        for column_name, expected_dtype in self.schema.items():
+        for col_info in self.schema.columns.values():
+            column_name = col_info.name
+            expected_dtype = col_info.data_type
             found_dtype = dtypes[column_name].name
             if found_dtype != expected_dtype:
                 if self.show_casting_warnings:
@@ -250,9 +297,9 @@ class DynamicDataIO:
                     if len(set(type(v) for v in df[column_name].values)) > 1:  # pylint: disable=consider-using-set-comprehension
                         logger.warning(CASTING_WARNING_MSG.format(column_name, expected_dtype, found_dtype))  # pylint: disable=logging-format-interpolation
                         logger.info(NOTICE_MSG.format(column_name))  # pylint: disable=logging-format-interpolation
-                    df[column_name] = df[column_name].astype(self.schema[column_name])
+                    df[column_name] = df[column_name].astype(self.schema.columns[column_name].data_type)
                 except (ValueError, TypeError):
-                    logger.error(f"ValueError: Tried casting column {self.name}['{column_name}]' to '{expected_dtype}' " f"from '{found_dtype}', but failed")
+                    logger.exception(f"ValueError: Tried casting column {self.name}['{column_name}'] to '{expected_dtype}' from '{found_dtype}', but failed")
                     return False
         return True
 

--- a/dynamicio/core.py
+++ b/dynamicio/core.py
@@ -14,7 +14,7 @@ from magic_logger import logger
 
 from dynamicio import validations
 from dynamicio.config.pydantic import DataframeSchema, IOEnvironment
-from dynamicio.errors import CASTING_WARNING_MSG, ColumnsDataTypeError, MissingSchemaDefinition, NOTICE_MSG, SchemaNotFoundError, SchemaValidationError
+from dynamicio.errors import CASTING_WARNING_MSG, ColumnsDataTypeError, NOTICE_MSG, SchemaNotFoundError, SchemaValidationError
 from dynamicio.metrics import get_metric
 
 SCHEMA_FROM_FILE = {"schema": object()}
@@ -205,7 +205,7 @@ class DynamicDataIO:
         for column in self.schema_validations.keys():
             col_validations = self.schema_validations[column]
             if not col_validations:
-                raise MissingSchemaDefinition(f"{self.__class__} is missing validations for {column} column")
+                continue
             for validation in col_validations:
                 if validation.apply:
                     validator = validations.ALL_VALIDATORS[validation.name]
@@ -228,14 +228,9 @@ class DynamicDataIO:
              self (to allow for method chaining).
         """
 
-        any_metrices = False
         for column in self.schema_metrics.keys():
             for metric in self.schema_metrics[column]:
-                any_metrices = True
                 get_metric(metric)(self.name, df, column)()  # type: ignore
-
-        if not any_metrices:
-            raise MissingSchemaDefinition(self.__class__)
 
         return self
 

--- a/dynamicio/core.py
+++ b/dynamicio/core.py
@@ -204,8 +204,6 @@ class DynamicDataIO:
         failed_validations = {}
         for column in self.schema_validations.keys():
             col_validations = self.schema_validations[column]
-            if not col_validations:
-                continue
             for validation in col_validations:
                 if validation.apply:
                     validator = validations.ALL_VALIDATORS[validation.name]

--- a/dynamicio/mixins/__init__.py
+++ b/dynamicio/mixins/__init__.py
@@ -1,16 +1,16 @@
 """Default dynamicio mixins module"""
 
-from .with_kafka import (
+from dynamicio.mixins.with_kafka import (
     WithKafka,
 )
-from .with_local import (
+from dynamicio.mixins.with_local import (
     WithLocal,
     WithLocalBatch,
 )
-from .with_postgres import (
+from dynamicio.mixins.with_postgres import (
     WithPostgres,
 )
-from .with_s3 import (
+from dynamicio.mixins.with_s3 import (
     WithS3File,
     WithS3PathPrefix,
 )

--- a/dynamicio/mixins/with_kafka.py
+++ b/dynamicio/mixins/with_kafka.py
@@ -11,7 +11,8 @@ from kafka import KafkaProducer  # type: ignore
 from magic_logger import logger
 
 
-from . import utils
+from dynamicio.config.pydantic import DataframeSchema, KafkaDataEnvironment
+from dynamicio.mixins import utils
 
 
 class WithKafka:
@@ -71,8 +72,8 @@ class WithKafka:
         >>> ]
     """
 
-    sources_config: Mapping
-    schema: Mapping
+    sources_config: KafkaDataEnvironment
+    schema: DataframeSchema
     options: MutableMapping[str, Any]
     __kafka_config: Optional[Mapping] = None
     __producer: Optional[KafkaProducer] = None
@@ -99,9 +100,9 @@ class WithKafka:
                 self.__document_transformer = self.options.pop("document_transformer")
 
         if self.__producer is None:
-            self.__producer = self._get_producer(self.sources_config["kafka"]["kafka_server"], **self.options)
+            self.__producer = self._get_producer(self.sources_config.kafka.kafka_server, **self.options)
 
-        self._send_messages(df=df, topic=self.sources_config["kafka"]["kafka_topic"])
+        self._send_messages(df=df, topic=self.sources_config.kafka.kafka_topic)
 
     @utils.allow_options(KafkaProducer.DEFAULT_CONFIG.keys())
     def _get_producer(self, server: str, **options: MutableMapping[str, Any]) -> KafkaProducer:

--- a/dynamicio/mixins/with_postgres.py
+++ b/dynamicio/mixins/with_postgres.py
@@ -5,7 +5,7 @@
 import csv
 import tempfile
 from contextlib import contextmanager
-from typing import Any, Dict, Generator, Mapping, MutableMapping, Union
+from typing import Any, Dict, Generator, MutableMapping, Union
 
 import pandas as pd  # type: ignore
 from magic_logger import logger
@@ -16,7 +16,8 @@ from sqlalchemy.orm.decl_api import DeclarativeMeta  # type: ignore
 from sqlalchemy.orm.session import Session as SqlAlchemySession  # type: ignore
 from sqlalchemy.orm.session import sessionmaker  # type: ignore
 
-from . import utils
+from dynamicio.config.pydantic import DataframeSchema, PostgresDataEnvironment
+from dynamicio.mixins import utils
 
 Session = sessionmaker(autoflush=True)
 
@@ -61,8 +62,8 @@ class WithPostgres:
            - `truncate_and_append: bool`: If set to `True`, truncates the table and then appends the new rows. Otherwise, it drops the table and recreates it with the new rows.
     """
 
-    sources_config: Mapping
-    schema: Mapping
+    sources_config: PostgresDataEnvironment
+    schema: DataframeSchema
     options: MutableMapping[str, Any]
 
     def _read_from_postgres(self) -> pd.DataFrame:
@@ -78,47 +79,40 @@ class WithPostgres:
         Returns:
             DataFrame
         """
-        postgres_config = self.sources_config["postgres"]
-        db_user = postgres_config["db_user"]
-        db_password = postgres_config["db_password"]
-        db_host = postgres_config["db_host"]
-        db_port = postgres_config["db_port"]
-        db_name = postgres_config["db_name"]
+        postgres_config = self.sources_config.postgres
+        db_user = postgres_config.db_user
+        db_password = postgres_config.db_password
+        db_host = postgres_config.db_host
+        db_port = postgres_config.db_port
+        db_name = postgres_config.db_name
 
         connection_string = f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
 
         sql_query = self.options.pop("sql_query", None)
 
-        if "schema" not in self.sources_config:
-            schema_dict = self.schema
-        else:
-            schema_dict = self.sources_config["schema"]
-        schema_name = self.sources_config["name"]
-
-        model = self._generate_model_from_schema(schema_dict, schema_name)
+        assert self.sources_config.dynamicio_schema is not None, "The schema must be specified for SQL tables"
+        model = self._generate_model_from_schema(self.sources_config.dynamicio_schema)
 
         query = Query(self._get_table_columns(model))
         if sql_query:
             query = sql_query
 
-        logger.info(f"[postgres] Started downloading table: {schema_name} from: {db_host}:{db_name}")
+        logger.info(f"[postgres] Started downloading table: {self.sources_config.dynamicio_schema.name} from: {db_host}:{db_name}")
         with session_for(connection_string) as session:
             return self._read_database(session, query, **self.options)
 
     @staticmethod
-    def _generate_model_from_schema(schema_dict: Mapping, schema_name: str) -> DeclarativeMeta:
-        json_cls_schema: Dict[str, Any] = {"tablename": schema_name, "columns": []}
+    def _generate_model_from_schema(schema: DataframeSchema) -> DeclarativeMeta:
+        json_cls_schema: Dict[str, Any] = {"tablename": schema.name, "columns": []}
 
-        for col, dtype in schema_dict.items():
-            new_col = {"name": col}
+        for col in schema.columns.values():
+            sql_type = _type_lookup.get(col.data_type)
+            if sql_type:
+                json_cls_schema["columns"].append({"name": col.name, "type": sql_type})
 
-            if dtype in _type_lookup:
-                new_col.update({"name": col, "type": _type_lookup[dtype]})
-                json_cls_schema["columns"].append(new_col)
+        class_name = "".join(word.capitalize() or "_" for word in schema.name.split("_")) + "Model"
 
-        class_name = "".join(word.capitalize() or "_" for word in schema_name.split("_")) + "Model"
-
-        class_dict = {"clsname": class_name, "__tablename__": schema_name, "__table_args__": {"extend_existing": True}}
+        class_dict = {"clsname": class_name, "__tablename__": schema.name, "__table_args__": {"extend_existing": True}}
         class_dict.update({column["name"]: Column(column["type"], primary_key=True) if idx == 0 else Column(column["type"]) for idx, column in enumerate(json_cls_schema["columns"])})
 
         generated_model = type(class_name, (Base,), class_dict)
@@ -155,22 +149,21 @@ class WithPostgres:
         Args:
             df: The dataframe to be written
         """
-        postgres_config = self.sources_config["postgres"]
-        db_user = postgres_config["db_user"]
-        db_password = postgres_config["db_password"]
-        db_host = postgres_config["db_host"]
-        db_port = postgres_config["db_port"]
-        db_name = postgres_config["db_name"]
+        postgres_config = self.sources_config.postgres
+        db_user = postgres_config.db_user
+        db_password = postgres_config.db_password
+        db_host = postgres_config.db_host
+        db_port = postgres_config.db_port
+        db_name = postgres_config.db_name
 
         connection_string = f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
 
-        schema_dict = self.sources_config["schema"]
-        schema_name = self.sources_config["name"]
-        model = self._generate_model_from_schema(schema_dict, schema_name)
+        assert self.sources_config.dynamicio_schema is not None, "The schema must be specified for SQL tables"
+        model = self._generate_model_from_schema(self.sources_config.dynamicio_schema)
 
         is_truncate_and_append = self.options.get("truncate_and_append", False)
 
-        logger.info(f"[postgres] Started downloading table: {schema_name} from: {db_host}:{db_name}")
+        logger.info(f"[postgres] Started downloading table: {self.sources_config.dynamicio_schema.name} from: {db_host}:{db_name}")
         with session_for(connection_string) as session:
             self._write_to_database(session, model.__tablename__, df, is_truncate_and_append)  # type: ignore
 

--- a/dynamicio/mixins/with_s3.py
+++ b/dynamicio/mixins/with_s3.py
@@ -18,8 +18,8 @@ import tables  # type: ignore
 from awscli.clidriver import create_clidriver  # type: ignore
 from magic_logger import logger
 
-
-from . import (
+from dynamicio.config.pydantic import DataframeSchema, S3DataEnvironment, S3PathPrefixEnvironment
+from dynamicio.mixins import (
     utils,
     with_local,
 )
@@ -111,6 +111,9 @@ class WithS3PathPrefix(with_local.WithLocal):
     This mixin assumes that the directories it reads from will only contain a single file-type.
     """
 
+    sources_config: S3PathPrefixEnvironment  # type: ignore
+    schema: DataframeSchema
+
     boto3_resource = boto3.resource("s3")
     boto3_client = boto3.client("s3")
 
@@ -129,18 +132,16 @@ class WithS3PathPrefix(with_local.WithLocal):
             ValueError: In case `path_prefix` is missing from config
             ValueError: In case the `partition_cols` arg is missing while trying to write a parquet file
         """
-        s3_config = self.sources_config["s3"]
-        if "path_prefix" not in s3_config:
-            raise ValueError("`path_prefix` is required to write multiple files to an S3 key")
+        s3_config = self.sources_config.s3
 
-        file_type = s3_config["file_type"]
+        file_type = s3_config.file_type
         if file_type != "parquet":
             raise ValueError(f"File type not supported: {file_type}, only parquet files can be written to an S3 key")
         if "partition_cols" not in self.options:
             raise ValueError("`partition_cols` is required as an option to write partitioned parquet files to S3")
 
-        bucket = s3_config["bucket"]
-        path_prefix = s3_config["path_prefix"]
+        bucket = s3_config.bucket
+        path_prefix = s3_config.path_prefix
         full_path_prefix = utils.resolve_template(f"s3://{bucket}/{path_prefix}", self.options)
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -170,16 +171,13 @@ class WithS3PathPrefix(with_local.WithLocal):
         Returns:
             DataFrame
         """
-        s3_config = self.sources_config["s3"]
-        if "path_prefix" not in s3_config:
-            raise ValueError("`path_prefix` is required to read multiple files from an S3 source")
-
-        file_type = s3_config["file_type"]
+        s3_config = self.sources_config.s3
+        file_type = s3_config.file_type
         if file_type not in {"parquet", "csv", "hdf", "json"}:
             raise ValueError(f"File type not supported: {file_type}")
 
-        bucket = s3_config["bucket"]
-        path_prefix = s3_config["path_prefix"]
+        bucket = s3_config.bucket
+        path_prefix = s3_config.path_prefix
         full_path_prefix = utils.resolve_template(f"s3://{bucket}/{path_prefix}", self.options)
 
         # The `no_disk_space` option should be used only when reading a subset of columns from S3
@@ -195,7 +193,7 @@ class WithS3PathPrefix(with_local.WithLocal):
                 ):
                     dfs.append(HdfIO().load(fobj))
                 df = pd.concat(dfs, ignore_index=True)
-                columns = [column for column in df.columns.to_list() if column in self.schema.keys()]
+                columns = [column for column in df.columns.to_list() if column in self.schema.columns.keys()]
                 return df[columns]
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -272,6 +270,9 @@ class WithS3File(with_local.WithLocal):
         no_disk_space: If `True`, then s3fs + fsspec will be used to read data directly into memory.
     """
 
+    sources_config: S3DataEnvironment  # type: ignore
+    schema: DataframeSchema
+
     boto3_client = boto3.client("s3")
 
     @contextmanager
@@ -345,19 +346,16 @@ class WithS3File(with_local.WithLocal):
         Returns:
             DataFrame
         """
-        s3_config = self.sources_config["s3"]
-        if "file_path" not in s3_config:
-            raise ValueError("`file_path` is required for reading a file from an S3 source")
+        s3_config = self.sources_config.s3
+        file_type = s3_config.file_type
+        file_path = utils.resolve_template(s3_config.file_path, self.options)
+        bucket = s3_config.bucket
 
-        file_type = s3_config["file_type"]
-        file_path = utils.resolve_template(s3_config["file_path"], self.options)
-        bucket = s3_config["bucket"]
-
-        logger.info(f"[s3] Started downloading: s3://{s3_config['bucket']}/{file_path}")
+        logger.info(f"[s3] Started downloading: s3://{s3_config.bucket}/{file_path}")
         if self.options.pop("no_disk_space", None):
             no_disk_space_rv = None
             if file_type in ["csv", "json", "parquet"]:
-                no_disk_space_rv = getattr(self, f"_read_{file_type}_file")(f"s3://{s3_config['bucket']}/{file_path}", self.schema, **self.options)  # type: ignore
+                no_disk_space_rv = getattr(self, f"_read_{file_type}_file")(f"s3://{s3_config.bucket}/{file_path}", self.schema, **self.options)  # type: ignore
             elif file_type == "hdf":
                 with self._s3_reader(s3_bucket=bucket, s3_key=file_path) as fobj:  # type: ignore
                     no_disk_space_rv = HdfIO().load(fobj)  # type: ignore
@@ -381,18 +379,19 @@ class WithS3File(with_local.WithLocal):
         Args:
             df: The dataframe to be written out
         """
-        s3_config = self.sources_config["s3"]
-        file_path = utils.resolve_template(s3_config["file_path"], self.options)
-        file_type = s3_config["file_type"]
+        s3_config = self.sources_config.s3
+        bucket = s3_config.bucket
+        file_path = utils.resolve_template(s3_config.file_path, self.options)
+        file_type = s3_config.file_type
 
-        logger.info(f"[s3] Started uploading: s3://{s3_config['bucket']}/{file_path}")
+        logger.info(f"[s3] Started uploading: s3://{bucket}/{file_path}")
         if file_type in ["csv", "json", "parquet"]:
-            getattr(self, f"_write_{file_type}_file")(df, f"s3://{s3_config['bucket']}/{file_path}", **self.options)  # type: ignore
+            getattr(self, f"_write_{file_type}_file")(df, f"s3://{bucket}/{file_path}", **self.options)  # type: ignore
         elif file_type == "hdf":
             hdf_options = dict(self.options)
             pickle_protocol = hdf_options.pop("pickle_protocol", None)
-            with self._s3_writer(s3_bucket=s3_config["bucket"], s3_key=file_path) as target_file, utils.pickle_protocol(protocol=pickle_protocol):
+            with self._s3_writer(s3_bucket=s3_config.bucket, s3_key=file_path) as target_file, utils.pickle_protocol(protocol=pickle_protocol):
                 HdfIO().save(df, target_file, hdf_options)  # type: ignore
         else:
             raise ValueError(f"File type: {file_type} not supported!")
-        logger.info(f"[s3] Finished uploading: s3://{s3_config['bucket']}/{file_path}")
+        logger.info(f"[s3] Finished uploading: s3://{bucket}/{file_path}")

--- a/dynamicio/validations.py
+++ b/dynamicio/validations.py
@@ -1,20 +1,18 @@
 """Implements the Validator class responsible for various generic data validations and metrics generation."""
-__all__ = [
-    "has_unique_values",
-    "has_no_null_values",
-    "has_acceptable_percentage_of_nulls",
-    "is_in",
-    "is_greater_than",
-    "is_greater_than_or_equal",
-    "is_lower_than",
-    "is_lower_than_or_equal",
-    "is_between",
-]
-
 import operator
-from typing import NamedTuple, Set
+from typing import Callable, NamedTuple, Set
 
 import pandas as pd  # type: ignore
+
+ALL_VALIDATORS = {}  # name -> function
+
+
+def validator(func: Callable):
+    """A decorator to add the function to the ALL_VALIDATORS dict"""
+    name = func.__name__
+    assert name not in ALL_VALIDATORS
+    ALL_VALIDATORS[name] = func
+    return func
 
 
 class ValidationResult(NamedTuple):
@@ -25,6 +23,7 @@ class ValidationResult(NamedTuple):
     value: float
 
 
+@validator
 def has_unique_values(dataset: str, df: pd.DataFrame, column: str) -> ValidationResult:
     """Checks if values in column are unique.
 
@@ -45,6 +44,7 @@ def has_unique_values(dataset: str, df: pd.DataFrame, column: str) -> Validation
     return ValidationResult(valid=False, message=f"Values {duplicates} for {dataset}[{column}] are duplicated!", value=len(duplicates))
 
 
+@validator
 def has_no_null_values(dataset: str, df: pd.DataFrame, column: str) -> ValidationResult:
     """Checks if column has any null values (including NaN and NaT values).
 
@@ -62,6 +62,7 @@ def has_no_null_values(dataset: str, df: pd.DataFrame, column: str) -> Validatio
     return ValidationResult(valid=not mask.any(), message=f"{dataset}[{column}] has {no_of_nulls} nulls", value=no_of_nulls)
 
 
+@validator
 def has_acceptable_percentage_of_nulls(
     dataset: str,
     df: pd.DataFrame,
@@ -104,6 +105,7 @@ def has_acceptable_percentage_of_nulls(
     )
 
 
+@validator
 def is_in(dataset: str, df: pd.DataFrame, column: str, categorical_values: Set[str], match_all: bool = True) -> ValidationResult:
     """Checks if the column only has allowed categorical values as per the set provided.
 
@@ -128,6 +130,7 @@ def is_in(dataset: str, df: pd.DataFrame, column: str, categorical_values: Set[s
     return _validate_all_acceptable_categoricals_are_present(categorical_values, unique_values, column, dataset, df)
 
 
+@validator
 def _validate_all_acceptable_categoricals_are_present(acceptable_categoricals: Set[str], unique_values: Set[str], column: str, dataset: str, df: pd.DataFrame) -> ValidationResult:
     if unique_values == acceptable_categoricals:
         validation_result = ValidationResult(valid=True, message=f"All acceptable categorical values for {dataset}[{column}] are present", value=0)
@@ -147,6 +150,7 @@ def _validate_all_acceptable_categoricals_are_present(acceptable_categoricals: S
     return validation_result
 
 
+@validator
 def _validate_categoricals_are_a_subset_of_the_acceptable(acceptable_categoricals: Set[str], unique_values: Set[str], column: str, dataset: str, df: pd.DataFrame) -> ValidationResult:
     if unique_values.issubset(acceptable_categoricals):
         return ValidationResult(valid=True, message=f"Categorical values for {dataset}[{column}] are acceptable", value=0)
@@ -158,6 +162,7 @@ def _validate_categoricals_are_a_subset_of_the_acceptable(acceptable_categorical
     )
 
 
+@validator
 def is_greater_than(
     dataset: str,
     df: pd.DataFrame,
@@ -191,6 +196,7 @@ def is_greater_than(
     )
 
 
+@validator
 def is_greater_than_or_equal(
     dataset: str,
     df: pd.DataFrame,
@@ -224,6 +230,7 @@ def is_greater_than_or_equal(
     )
 
 
+@validator
 def is_lower_than(
     dataset: str,
     df: pd.DataFrame,
@@ -259,6 +266,7 @@ def is_lower_than(
     )
 
 
+@validator
 def is_lower_than_or_equal(
     dataset: str,
     df: pd.DataFrame,
@@ -294,6 +302,7 @@ def is_lower_than_or_equal(
     )
 
 
+@validator
 def is_between(
     dataset: str,
     df: pd.DataFrame,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ coverage-badge==1.1.0
 flake8==5.0.4
 flake8-print>=5.0.0
 flake8-import-order>=0.18.0
+flake8-tidy-imports>=4.8.0
 gitlint==0.17.0
 mock==4.0.3
 mypy==0.990

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ s3fs==0.4.2
 simplejson~=3.17.2
 SQLAlchemy>=1.4.11
 tables~=3.7.0
+pydantic~=1.10.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,257 +52,494 @@ class DummyYaml:
         return None
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def expected_input_yaml_dict():
     return {
-        "READ_FROM_KAFKA": {
-            "CLOUD": {
-                "kafka": {"kafka_server": "mock-kafka-server", "kafka_topic": "mock-kafka-topic"},
-                "type": "kafka",
-            },
-            "LOCAL": {
-                "local": {
-                    "file_path": f"{constants.TEST_RESOURCES}/data/input/some_parquet_to_read.parquet",
-                    "file_type": "parquet",
+        "bindings": {
+            "READ_FROM_S3_CSV_ALT": {
+                "name": "READ_FROM_S3_CSV_ALT",
+                "environments": {
+                    "LOCAL": {
+                        "options": {},
+                        "data_backend_type": "local",
+                        "local": {
+                            "file_path": f"{constants.TEST_RESOURCES}/data/input/some_csv_to_read.csv",
+                            "file_type": "csv",
+                        },
+                    },
+                    "CLOUD": {
+                        "options": {},
+                        "data_backend_type": "s3",
+                        "s3": {
+                            "file_path": "mock-key",
+                            "file_type": "csv",
+                            "bucket": "mock-bucket",
+                        },
+                    },
                 },
-                "type": "local",
+                "dynamicio_schema": None,
             },
-        },
-        "READ_FROM_PARQUET_TEMPLATED": {
-            "CLOUD": {
-                "s3": {
-                    "bucket": "mock-bucket",
-                    "file_path": "path/to/{file_name_to_replace}.parquet",
-                    "file_type": "parquet",
+            "READ_FROM_S3_CSV": {
+                "name": "READ_FROM_S3_CSV",
+                "environments": {
+                    "LOCAL": {
+                        "options": {},
+                        "data_backend_type": "local",
+                        "local": {
+                            "file_path": f"{constants.TEST_RESOURCES}/data/input/some_csv_to_read.csv",
+                            "file_type": "csv",
+                        },
+                    },
+                    "CLOUD": {
+                        "options": {},
+                        "data_backend_type": "s3",
+                        "s3": {
+                            "file_path": "mock-key",
+                            "file_type": "csv",
+                            "bucket": "mock-bucket",
+                        },
+                    },
                 },
-                "type": "s3",
-            },
-            "LOCAL": {
-                "local": {
-                    "file_path": f"{constants.TEST_RESOURCES}/data/input/{{file_name_to_replace}}.parquet",
-                    "file_type": "parquet",
+                "dynamicio_schema": {
+                    "name": "read_from_s3_csv",
+                    "columns": {
+                        "id": {
+                            "name": "id",
+                            "data_type": "int64",
+                            "validations": [
+                                {"name": "has_unique_values", "apply": True, "options": {}},
+                                {
+                                    "name": "has_no_null_values",
+                                    "apply": True,
+                                    "options": {},
+                                },
+                            ],
+                            "metrics": ["UniqueCounts", "Counts"],
+                        },
+                        "foo_name": {
+                            "name": "foo_name",
+                            "data_type": "object",
+                            "validations": [
+                                {
+                                    "name": "has_no_null_values",
+                                    "apply": True,
+                                    "options": {},
+                                },
+                                {
+                                    "name": "is_in",
+                                    "apply": True,
+                                    "options": {
+                                        "categorical_values": [
+                                            "class_a",
+                                            "class_b",
+                                            "class_c",
+                                        ]
+                                    },
+                                },
+                            ],
+                            "metrics": ["CountsPerLabel"],
+                        },
+                        "bar": {
+                            "name": "bar",
+                            "data_type": "int64",
+                            "validations": [
+                                {
+                                    "name": "has_no_null_values",
+                                    "apply": True,
+                                    "options": {},
+                                },
+                                {
+                                    "name": "is_greater_than",
+                                    "apply": True,
+                                    "options": {"threshold": 1000},
+                                },
+                                {
+                                    "name": "is_lower_than",
+                                    "apply": True,
+                                    "options": {"threshold": 2000},
+                                },
+                            ],
+                            "metrics": ["Min", "Max", "Mean", "Std", "Variance"],
+                        },
+                    },
                 },
-                "type": "local",
             },
-        },
-        "READ_FROM_POSTGRES": {
-            "CLOUD": {
-                "postgres": {
-                    "db_host": "127.0.0.1",
-                    "db_name": "backend",
-                    "db_password": "pass",
-                    "db_port": "17039",
-                    "db_user": "user",
+            "READ_FROM_S3_JSON": {
+                "name": "READ_FROM_S3_JSON",
+                "environments": {
+                    "LOCAL": {
+                        "options": {},
+                        "data_backend_type": "local",
+                        "local": {
+                            "file_path": f"{constants.TEST_RESOURCES}/data/input/some_json_to_read.json",
+                            "file_type": "json",
+                        },
+                    },
+                    "CLOUD": {
+                        "options": {},
+                        "data_backend_type": "s3",
+                        "s3": {
+                            "file_path": "mock-key",
+                            "file_type": "json",
+                            "bucket": "mock-bucket",
+                        },
+                    },
                 },
-                "type": "postgres",
+                "dynamicio_schema": None,
             },
-            "LOCAL": {
-                "local": {
-                    "file_path": f"{constants.TEST_RESOURCES}/data/input/some_pg_parquet_to_read.parquet",
-                    "file_type": "parquet",
+            "READ_FROM_S3_HDF": {
+                "name": "READ_FROM_S3_HDF",
+                "environments": {
+                    "LOCAL": {
+                        "options": {},
+                        "data_backend_type": "local",
+                        "local": {
+                            "file_path": f"{constants.TEST_RESOURCES}/data/input/some_hdf_to_read.h5",
+                            "file_type": "hdf",
+                        },
+                    },
+                    "CLOUD": {
+                        "options": {},
+                        "data_backend_type": "s3",
+                        "s3": {
+                            "file_path": "mock-key",
+                            "file_type": "hdf",
+                            "bucket": "mock-bucket",
+                        },
+                    },
                 },
-                "type": "local",
+                "dynamicio_schema": None,
             },
-        },
-        "READ_FROM_S3_CSV": {
-            "CLOUD": {
-                "s3": {"bucket": "mock-bucket", "file_path": "mock-key", "file_type": "csv"},
-                "type": "s3",
-            },
-            "LOCAL": {
-                "local": {
-                    "file_path": f"{constants.TEST_RESOURCES}/data/input/some_csv_to_read.csv",
-                    "file_type": "csv",
+            "READ_FROM_S3_PARQUET": {
+                "name": "READ_FROM_S3_PARQUET",
+                "environments": {
+                    "LOCAL": {
+                        "options": {},
+                        "data_backend_type": "local",
+                        "local": {
+                            "file_path": f"{constants.TEST_RESOURCES}/data/input/some_parquet_to_read.parquet",
+                            "file_type": "parquet",
+                        },
+                    },
+                    "CLOUD": {
+                        "options": {},
+                        "data_backend_type": "s3",
+                        "s3": {
+                            "file_path": "s3:sample-prefix/mock-key",
+                            "file_type": "parquet",
+                            "bucket": "mock-bucket",
+                        },
+                    },
                 },
-                "type": "local",
+                "dynamicio_schema": None,
             },
-            "schema": {"file_path": f"{constants.TEST_RESOURCES}/schemas/read_from_s3_csv.yaml"},
-        },
-        "READ_FROM_S3_CSV_ALT": {
-            "CLOUD": {
-                "s3": {"bucket": "mock-bucket", "file_path": "mock-key", "file_type": "csv"},
-                "type": "s3",
-            },
-            "LOCAL": {
-                "local": {
-                    "file_path": f"{constants.TEST_RESOURCES}/data/input/some_csv_to_read.csv",
-                    "file_type": "csv",
+            "READ_FROM_POSTGRES": {
+                "name": "READ_FROM_POSTGRES",
+                "environments": {
+                    "LOCAL": {
+                        "options": {},
+                        "data_backend_type": "local",
+                        "local": {
+                            "file_path": f"{constants.TEST_RESOURCES}/data/input/some_pg_parquet_to_read.parquet",
+                            "file_type": "parquet",
+                        },
+                    },
+                    "CLOUD": {
+                        "options": {},
+                        "data_backend_type": "postgres",
+                        "postgres": {
+                            "db_host": "127.0.0.1",
+                            "db_port": "17039",
+                            "db_name": "backend",
+                            "db_user": "user",
+                            "db_password": "pass",
+                        },
+                    },
                 },
-                "type": "local",
+                "dynamicio_schema": None,
             },
-        },
-        "READ_FROM_S3_HDF": {
-            "CLOUD": {
-                "s3": {"bucket": "mock-bucket", "file_path": "mock-key", "file_type": "hdf"},
-                "type": "s3",
-            },
-            "LOCAL": {
-                "local": {
-                    "file_path": f"{constants.TEST_RESOURCES}/data/input/some_hdf_to_read.h5",
-                    "file_type": "hdf",
+            "READ_FROM_KAFKA": {
+                "name": "READ_FROM_KAFKA",
+                "environments": {
+                    "LOCAL": {
+                        "options": {},
+                        "data_backend_type": "local",
+                        "local": {
+                            "file_path": f"{constants.TEST_RESOURCES}/data/input/some_parquet_to_read.parquet",
+                            "file_type": "parquet",
+                        },
+                    },
+                    "CLOUD": {
+                        "options": {},
+                        "data_backend_type": "kafka",
+                        "kafka": {
+                            "kafka_server": "mock-kafka-server",
+                            "kafka_topic": "mock-kafka-topic",
+                        },
+                    },
                 },
-                "type": "local",
+                "dynamicio_schema": None,
             },
-        },
-        "READ_FROM_S3_JSON": {
-            "CLOUD": {
-                "s3": {"bucket": "mock-bucket", "file_path": "mock-key", "file_type": "json"},
-                "type": "s3",
-            },
-            "LOCAL": {
-                "local": {
-                    "file_path": f"{constants.TEST_RESOURCES}/data/input/some_json_to_read.json",
-                    "file_type": "json",
+            "TEMPLATED_FILE_PATH": {
+                "name": "TEMPLATED_FILE_PATH",
+                "environments": {
+                    "LOCAL": {
+                        "options": {},
+                        "data_backend_type": "local",
+                        "local": {
+                            "file_path": f"{constants.TEST_RESOURCES}/data/input/{{file_name_to_replace}}.csv",
+                            "file_type": "csv",
+                        },
+                    },
+                    "CLOUD": {
+                        "options": {},
+                        "data_backend_type": "s3",
+                        "s3": {
+                            "file_path": "path/to/{file_name_to_replace}.csv",
+                            "file_type": "csv",
+                            "bucket": "mock-bucket",
+                        },
+                    },
                 },
-                "type": "local",
+                "dynamicio_schema": None,
             },
-        },
-        "READ_FROM_S3_PARQUET": {
-            "CLOUD": {
-                "s3": {
-                    "bucket": "mock-bucket",
-                    "file_path": "s3:sample-prefix/mock-key",
-                    "file_type": "parquet",
+            "READ_FROM_PARQUET_TEMPLATED": {
+                "name": "READ_FROM_PARQUET_TEMPLATED",
+                "environments": {
+                    "LOCAL": {
+                        "options": {},
+                        "data_backend_type": "local",
+                        "local": {
+                            "file_path": f"{constants.TEST_RESOURCES}/data/input/{{file_name_to_replace}}.parquet",
+                            "file_type": "parquet",
+                        },
+                    },
+                    "CLOUD": {
+                        "options": {},
+                        "data_backend_type": "s3",
+                        "s3": {
+                            "file_path": "path/to/{file_name_to_replace}.parquet",
+                            "file_type": "parquet",
+                            "bucket": "mock-bucket",
+                        },
+                    },
                 },
-                "type": "s3",
+                "dynamicio_schema": None,
             },
-            "LOCAL": {
-                "local": {
-                    "file_path": f"{constants.TEST_RESOURCES}/data/input/some_parquet_to_read.parquet",
-                    "file_type": "parquet",
+            "REPLACE_SCHEMA_WITH_DYN_VARS": {
+                "name": "REPLACE_SCHEMA_WITH_DYN_VARS",
+                "environments": {
+                    "LOCAL": {
+                        "options": {},
+                        "data_backend_type": "local",
+                        "local": {
+                            "file_path": f"{constants.TEST_RESOURCES}/data/input/{{file_name_to_replace}}.parquet",
+                            "file_type": "parquet",
+                        },
+                    }
                 },
-                "type": "local",
-            },
-        },
-        'REPLACE_SCHEMA_WITH_DYN_VARS': {
-            'LOCAL': {
-                'local': {
-                    'file_path': f'{constants.TEST_RESOURCES}/data/input/{{file_name_to_replace}}.parquet',
-                    'file_type': 'parquet'},
-                'type': 'local'},
-            'schema': {
-                'file_path': f'{constants.TEST_RESOURCES}/schemas/bar.yaml'}
-        },
-        "TEMPLATED_FILE_PATH": {
-            "CLOUD": {
-                "s3": {
-                    "bucket": "mock-bucket",
-                    "file_path": "path/to/{file_name_to_replace}.csv",
-                    "file_type": "csv",
+                "dynamicio_schema": {
+                    "name": "bar",
+                    "columns": {
+                        "column_a": {
+                            "name": "column_a",
+                            "data_type": "object",
+                            "validations": [
+                                {"name": "has_unique_values", "apply": True, "options": {}}
+                            ],
+                            "metrics": ["Counts"],
+                        },
+                        "column_b": {
+                            "name": "column_b",
+                            "data_type": "object",
+                            "validations": [
+                                {"name": "has_no_null_values", "apply": True, "options": {}}
+                            ],
+                            "metrics": ["CountsPerLabel"],
+                        },
+                        "column_c": {
+                            "name": "column_c",
+                            "data_type": "float64",
+                            "validations": [
+                                {
+                                    "name": "is_greater_than",
+                                    "apply": True,
+                                    "options": {"threshold": 1000},
+                                }
+                            ],
+                            "metrics": [],
+                        },
+                        "column_d": {
+                            "name": "column_d",
+                            "data_type": "float64",
+                            "validations": [
+                                {
+                                    "name": "is_lower_than",
+                                    "apply": True,
+                                    "options": {"threshold": 1000.0},
+                                }
+                            ],
+                            "metrics": ["Min", "Max", "Mean", "Std", "Variance"],
+                        },
+                        "0": {
+                            "name": "0",
+                            "data_type": "object",
+                            "validations": [],
+                            "metrics": [],
+                        },
+                        "1": {
+                            "name": "1",
+                            "data_type": "object",
+                            "validations": [],
+                            "metrics": [],
+                        },
+                    },
                 },
-                "type": "s3",
             },
-            "LOCAL": {
-                "local": {
-                    "file_path": f"{constants.TEST_RESOURCES}/data/input/{{file_name_to_replace}}.csv",
-                    "file_type": "csv",
-                },
-                "type": "local",
-            },
-        },
+        }
     }
 
 
-@pytest.fixture(scope="class")
-def expected_input_sources():
-    return [
-        "READ_FROM_S3_CSV_ALT",
-        "READ_FROM_S3_CSV",
-        "READ_FROM_S3_JSON",
-        "READ_FROM_S3_HDF",
-        "READ_FROM_S3_PARQUET",
-        "READ_FROM_POSTGRES",
-        "READ_FROM_KAFKA",
-        "TEMPLATED_FILE_PATH",
-        "READ_FROM_PARQUET_TEMPLATED",
-        "REPLACE_SCHEMA_WITH_DYN_VARS"
-    ]
-
-
-@pytest.fixture(scope="class")
+@pytest.fixture
 def expected_s3_csv_local_mapping():
     return {
-        "local": {
-            "file_path": f"{constants.TEST_RESOURCES}/data/input/some_csv_to_read.csv",
-            "file_type": "csv",
-        },
-        "metrics": {
-            "id": ["UniqueCounts", "Counts"],
-            "bar": ["Min", "Max", "Mean", "Std", "Variance"],
-            "foo_name": ["CountsPerLabel"],
-        },
-        "schema": {"id": "int64", "bar": "int64", "foo_name": "object"},
-        "type": "local",
-        "validations": {
-            "id": {
-                "has_no_null_values": {"apply": True, "options": {}},
-                "has_unique_values": {"apply": True, "options": {}},
-            },
-            "bar": {
-                "has_no_null_values": {"apply": True, "options": {}},
-                "is_greater_than": {"apply": True, "options": {"threshold": 1000}},
-                "is_lower_than": {"apply": True, "options": {"threshold": 2000}},
-            },
-            "foo_name": {
-                "is_in": {
-                    "apply": True,
-                    "options": {"categorical_values": ["class_a", "class_b", "class_c"]},
+        "name": "READ_FROM_S3_CSV",
+        "environments": {
+            "LOCAL": {
+                "options": {},
+                "data_backend_type": "local",
+                "local": {
+                    "file_path": f"{constants.TEST_RESOURCES}/data/input/some_csv_to_read.csv",
+                    "file_type": "csv",
                 },
-                "has_no_null_values": {"apply": True, "options": {}},
+            },
+            "CLOUD": {
+                "options": {},
+                "data_backend_type": "s3",
+                "s3": {
+                    "file_path": "mock-key",
+                    "file_type": "csv",
+                    "bucket": "mock-bucket",
+                },
             },
         },
-        "name": "read_from_s3_csv"
+        "dynamicio_schema": {
+            "name": "read_from_s3_csv",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "data_type": "int64",
+                    "validations": [
+                        {"name": "has_unique_values", "apply": True, "options": {}},
+                        {"name": "has_no_null_values", "apply": True, "options": {}},
+                    ],
+                    "metrics": ["UniqueCounts", "Counts"],
+                },
+                "foo_name": {
+                    "name": "foo_name",
+                    "data_type": "object",
+                    "validations": [
+                        {"name": "has_no_null_values", "apply": True, "options": {}},
+                        {
+                            "name": "is_in",
+                            "apply": True,
+                            "options": {
+                                "categorical_values": ["class_a", "class_b", "class_c"]
+                            },
+                        },
+                    ],
+                    "metrics": ["CountsPerLabel"],
+                },
+                "bar": {
+                    "name": "bar",
+                    "data_type": "int64",
+                    "validations": [
+                        {"name": "has_no_null_values", "apply": True, "options": {}},
+                        {
+                            "name": "is_greater_than",
+                            "apply": True,
+                            "options": {"threshold": 1000},
+                        },
+                        {
+                            "name": "is_lower_than",
+                            "apply": True,
+                            "options": {"threshold": 2000},
+                        },
+                    ],
+                    "metrics": ["Min", "Max", "Mean", "Std", "Variance"],
+                },
+            },
+        },
     }
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def expected_s3_csv_cloud_mapping():
     return {
-        "metrics": {
-            "id": ["UniqueCounts", "Counts"],
-            "bar": ["Min", "Max", "Mean", "Std", "Variance"],
-            "foo_name": ["CountsPerLabel"],
-        },
-        "s3": {"bucket": "mock-bucket", "file_path": "mock-key", "file_type": "csv"},
-        "schema": {"id": "int64", "bar": "int64", "foo_name": "object"},
-        "type": "s3",
-        "validations": {
+        "name": "read_from_s3_csv",
+        "columns": {
             "id": {
-                "has_no_null_values": {"apply": True, "options": {}},
-                "has_unique_values": {"apply": True, "options": {}},
-            },
-            "bar": {
-                "has_no_null_values": {"apply": True, "options": {}},
-                "is_greater_than": {"apply": True, "options": {"threshold": 1000}},
-                "is_lower_than": {"apply": True, "options": {"threshold": 2000}},
+                "name": "id",
+                "data_type": "int64",
+                "validations": [
+                    {"name": "has_unique_values", "apply": True, "options": {}},
+                    {"name": "has_no_null_values", "apply": True, "options": {}},
+                ],
+                "metrics": ["UniqueCounts", "Counts"],
             },
             "foo_name": {
-                "is_in": {
-                    "apply": True,
-                    "options": {"categorical_values": ["class_a", "class_b", "class_c"]},
-                },
-                "has_no_null_values": {"apply": True, "options": {}},
+                "name": "foo_name",
+                "data_type": "object",
+                "validations": [
+                    {"name": "has_no_null_values", "apply": True, "options": {}},
+                    {
+                        "name": "is_in",
+                        "apply": True,
+                        "options": {
+                            "categorical_values": ["class_a", "class_b", "class_c"]
+                        },
+                    },
+                ],
+                "metrics": ["CountsPerLabel"],
+            },
+            "bar": {
+                "name": "bar",
+                "data_type": "int64",
+                "validations": [
+                    {"name": "has_no_null_values", "apply": True, "options": {}},
+                    {
+                        "name": "is_greater_than",
+                        "apply": True,
+                        "options": {"threshold": 1000},
+                    },
+                    {
+                        "name": "is_lower_than",
+                        "apply": True,
+                        "options": {"threshold": 2000},
+                    },
+                ],
+                "metrics": ["Min", "Max", "Mean", "Std", "Variance"],
             },
         },
-        "name": "read_from_s3_csv"
     }
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def expected_postgres_cloud_mapping():
     return {
+        "options": {},
+        "data_backend_type": "postgres",
         "postgres": {
             "db_host": "127.0.0.1",
-            "db_name": "backend",
-            "db_password": "pass",
             "db_port": "17039",
+            "db_name": "backend",
             "db_user": "user",
+            "db_password": "pass",
         },
-        "type": "postgres",
     }
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def expected_s3_parquet_df():
     return pd.read_parquet(f"{constants.TEST_RESOURCES}/data/input/some_parquet_to_read.parquet")
 
@@ -317,17 +554,17 @@ def expected_s3_hdf_df(expected_s3_hdf_file_path):  # pylint: disable=redefined-
     return pd.read_hdf(expected_s3_hdf_file_path)
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def expected_s3_json_df():
     return pd.read_json(f"{constants.TEST_RESOURCES}/data/input/some_json_to_read.json", orient="columns")
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def expected_s3_csv_df():
     return pd.read_csv(f"{constants.TEST_RESOURCES}/data/input/some_csv_to_read.csv")
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def expected_df_with_less_columns():
     df = pd.DataFrame.from_records(
         [
@@ -352,7 +589,7 @@ def expected_df_with_less_columns():
     return df
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def dataset_with_more_columns_than_dictated_in_schema():
     df = pd.DataFrame.from_records(
         [
@@ -377,7 +614,7 @@ def dataset_with_more_columns_than_dictated_in_schema():
     return df
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def test_df():
     df = pd.DataFrame.from_records(
         [
@@ -390,22 +627,22 @@ def test_df():
     return df
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def expected_columns():
     return [ERModel.id, ERModel.foo, ERModel.bar, ERModel.baz]
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def expected_kwargs_for_read_parquet():
     return {"engine", "columns", "kwargs", "path", "use_nullable_dtypes"}
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def expected_value_serializer():
     return {'value_serializer': 'WithKafka._default_value_serializer'}
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def input_messages_df():
     return pd.DataFrame.from_dict(
         [
@@ -415,7 +652,7 @@ def input_messages_df():
     )
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def input_schema_definition():
     return {
         "columns": {
@@ -452,80 +689,85 @@ def input_schema_definition():
     }
 
 
-@pytest.fixture(scope="class")
-def expected_schema():
-    return {"id": "int64", "foo_name": "object", "bar": "int64"}
+# @pytest.fixture
+# def expected_schema():
+#     return {"id": "int64", "foo_name": "object", "bar": "int64"}
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def expected_schema_definition():
     return {
-        "columns": {
-            "id": {
-                "metrics": ["UniqueCounts", "Counts"],
-                "type": "int64",
-                "validations": {
-                    "has_no_null_values": {"apply": True, "options": {}},
-                    "has_unique_values": {"apply": True, "options": {}},
+        "name": "READ_FROM_S3_CSV",
+        "environments": {
+            "LOCAL": {
+                "options": {},
+                "data_backend_type": "local",
+                "local": {
+                    "file_path": f"{constants.TEST_RESOURCES}/data/input/some_csv_to_read.csv",
+                    "file_type": "csv",
                 },
             },
-            "bar": {
-                "metrics": ["Min", "Max", "Mean", "Std", "Variance"],
-                "type": "int64",
-                "validations": {
-                    "has_no_null_values": {"apply": True, "options": {}},
-                    "is_greater_than": {"apply": True, "options": {"threshold": 1000}},
-                    "is_lower_than": {"apply": True, "options": {"threshold": 2000}},
-                },
-            },
-            "foo_name": {
-                "metrics": ["CountsPerLabel"],
-                "type": "object",
-                "validations": {
-                    "is_in": {
-                        "apply": True,
-                        "options": {"categorical_values": ["class_a", "class_b", "class_c"]},
-                    },
-                    "has_no_null_values": {"apply": True, "options": {}},
+            "CLOUD": {
+                "options": {},
+                "data_backend_type": "s3",
+                "s3": {
+                    "file_path": "mock-key",
+                    "file_type": "csv",
+                    "bucket": "mock-bucket",
                 },
             },
         },
-        "name": "read_from_s3_csv",
-    }
-
-
-@pytest.fixture(scope="class")
-def expected_validations():
-    return {
-        "id": {
-            "has_no_null_values": {"apply": True, "options": {}},
-            "has_unique_values": {"apply": True, "options": {}},
-        },
-        "bar": {
-            "has_no_null_values": {"apply": True, "options": {}},
-            "is_greater_than": {"apply": True, "options": {"threshold": 1000}},
-            "is_lower_than": {"apply": True, "options": {"threshold": 2000}},
-        },
-        "foo_name": {
-            "is_in": {
-                "apply": True,
-                "options": {"categorical_values": ["class_a", "class_b", "class_c"]},
+        "dynamicio_schema": {
+            "name": "read_from_s3_csv",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "data_type": "int64",
+                    "validations": [
+                        {"name": "has_unique_values", "apply": True, "options": {}},
+                        {"name": "has_no_null_values", "apply": True, "options": {}},
+                    ],
+                    "metrics": ["UniqueCounts", "Counts"],
+                },
+                "foo_name": {
+                    "name": "foo_name",
+                    "data_type": "object",
+                    "validations": [
+                        {"name": "has_no_null_values", "apply": True, "options": {}},
+                        {
+                            "name": "is_in",
+                            "apply": True,
+                            "options": {
+                                "categorical_values": ["class_a", "class_b", "class_c"]
+                            },
+                        },
+                    ],
+                    "metrics": ["CountsPerLabel"],
+                },
+                "bar": {
+                    "name": "bar",
+                    "data_type": "int64",
+                    "validations": [
+                        {"name": "has_no_null_values", "apply": True, "options": {}},
+                        {
+                            "name": "is_greater_than",
+                            "apply": True,
+                            "options": {"threshold": 1000},
+                        },
+                        {
+                            "name": "is_lower_than",
+                            "apply": True,
+                            "options": {"threshold": 2000},
+                        },
+                    ],
+                    "metrics": ["Min", "Max", "Mean", "Std", "Variance"],
+                },
             },
-            "has_no_null_values": {"apply": True, "options": {}},
         },
     }
 
 
-@pytest.fixture(scope="class")
-def expected_metrics():
-    return {
-        "id": ["UniqueCounts", "Counts"],
-        "bar": ["Min", "Max", "Mean", "Std", "Var"],
-        "foo_name": None,
-    }
-
-
-@pytest.fixture(scope="class")
+@pytest.fixture
 def valid_dataframe():
     return pd.DataFrame.from_dict(
         {
@@ -536,7 +778,7 @@ def valid_dataframe():
     )
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def invalid_dataframe():
     return pd.DataFrame.from_dict(
         {
@@ -547,7 +789,7 @@ def invalid_dataframe():
     )
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def expected_messages():
     return {
         "has_unique_values",
@@ -557,7 +799,7 @@ def expected_messages():
     }
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def input_df():
     return pd.DataFrame.from_records(
         [
@@ -576,7 +818,7 @@ def input_df():
     )
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def empty_df():
     return pd.DataFrame.from_records(
         [],

--- a/tests/mocking/io.py
+++ b/tests/mocking/io.py
@@ -12,10 +12,6 @@ class ReadMockS3CsvIO(UnifiedIO):
     schema = SCHEMA_FROM_FILE
 
 
-class ReadS3CsvAltIO(UnifiedIO):
-    schema = {"id": "int64", "foo_name": "object", "bar": "int64"}
-
-
 class TemplatedFile(UnifiedIO):
     schema = {"id": "int64", "foo_name": "object", "bar": "int64"}
 

--- a/tests/resources/definitions/input.yaml
+++ b/tests/resources/definitions/input.yaml
@@ -120,42 +120,6 @@ READ_FROM_S3_PATH_PREFIX_JSON:
       path_prefix: "[[ MOCK_KEY ]]"
       file_type: "json"
 
-READ_FROM_S3_PATH_PREFIX_TXT:
-  CLOUD:
-    type: "s3_path_prefix"
-    s3:
-      bucket: "[[ MOCK_BUCKET ]]"
-      path_prefix: "[[ MOCK_KEY ]]"
-      file_type: "txt"
-
-READ_FROM_S3_MISSING_PATH_PREFIX:
-  LOCAL:
-    type: "local"
-    local:
-      file_path: "[[ TEST_RESOURCES ]]/data/input/some_csv_to_read.csv"
-      file_type: "csv"
-  CLOUD:
-    type: "s3_path_prefix"
-    s3:
-      bucket: "[[ MOCK_BUCKET ]]"
-      file_type: "csv"
-  schema:
-    file_path: "[[ TEST_RESOURCES ]]/schemas/read_from_s3_csv.yaml"
-
-READ_FROM_S3_MISSING_FILE_PATH:
-  LOCAL:
-    type: "local"
-    local:
-      file_path: "[[ TEST_RESOURCES ]]/data/input/some_csv_to_read.csv"
-      file_type: "csv"
-  CLOUD:
-    type: "s3_file"
-    s3:
-      bucket: "[[ MOCK_BUCKET ]]"
-      file_type: "csv"
-  schema:
-    file_path: "[[ TEST_RESOURCES ]]/schemas/read_from_s3_csv.yaml"
-
 READ_FROM_POSTGRES:
   LOCAL:
     type: "local"
@@ -321,10 +285,3 @@ WRITE_TO_S3_PATH_PREFIX_PARQUET:
       path_prefix: "[[ MOCK_KEY ]]"
       file_type: "parquet"
 
-WRITE_TO_S3_PATH_PREFIX_NOT_PARQUET:
-  CLOUD:
-    type: "s3_path_prefix"
-    s3:
-      bucket: "[[ MOCK_BUCKET ]]"
-      path_prefix: "[[ MOCK_KEY ]]"
-      file_type: "not_parquet"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,7 +13,7 @@ import pytest
 import dynamicio
 from dynamicio.config import IOConfig
 from dynamicio.core import CASTING_WARNING_MSG, DynamicDataIO
-from dynamicio.errors import ColumnsDataTypeError, MissingSchemaDefinition, SchemaNotFoundError, SchemaValidationError
+from dynamicio.errors import ColumnsDataTypeError, SchemaNotFoundError, SchemaValidationError
 from dynamicio.mixins import WithS3File
 from tests import constants
 from tests.mocking.io import (
@@ -23,7 +23,6 @@ from tests.mocking.io import (
     ParquetWithCustomValidate,
     ParquetWithSomeBool,
     ReadMockS3CsvIO,
-    ReadS3CsvAltIO,
     ReadS3CsvIO,
     ReadS3DataWithFalseTypes,
     ReadS3IO,
@@ -184,34 +183,6 @@ class TestCoreIO:
         # When
         with pytest.raises(SchemaNotFoundError):
             ReadMockS3CsvIO(source_config=read_mock_s3_cloud_config)
-
-    @pytest.mark.unit
-    def test_missing_schema_definition_error_is_thrown_if_user_tries_to_use_validate_from_schema_without_one(self, valid_dataframe):
-        # Given
-        df = valid_dataframe
-        read_alt_cloud_config = IOConfig(
-            path_to_source_yaml=(os.path.join(constants.TEST_RESOURCES, "definitions/input.yaml")),
-            env_identifier="CLOUD",
-            dynamic_vars=constants,
-        ).get(source_key="READ_FROM_S3_CSV_ALT")
-
-        # When
-        with pytest.raises(MissingSchemaDefinition):
-            ReadS3CsvAltIO(source_config=read_alt_cloud_config).validate_from_schema(df)
-
-    @pytest.mark.unit
-    def test_missing_schema_definition_error_is_thrown_if_user_tries_to_use_log_metrics_from_schema(self, valid_dataframe):
-        # Given
-        df = valid_dataframe
-        read_alt_cloud_config = IOConfig(
-            path_to_source_yaml=(os.path.join(constants.TEST_RESOURCES, "definitions/input.yaml")),
-            env_identifier="CLOUD",
-            dynamic_vars=constants,
-        ).get(source_key="READ_FROM_S3_CSV_ALT")
-
-        # When
-        with pytest.raises(MissingSchemaDefinition):
-            ReadS3CsvAltIO(source_config=read_alt_cloud_config).log_metrics_from_schema(df)
 
     @pytest.mark.integration
     def test_schema_validations_are_applied_for_an_io_class_with_a_schema_definition(self, valid_dataframe):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -151,7 +151,7 @@ class TestCoreIO:
         with pytest.raises(AssertionError):
 
             class CMVolumesIONoValidationFunction(DynamicDataIO):
-                schema = {"foo": "bar"}
+                schema = {"foo": "int64"}
 
             CMVolumesIONoValidationFunction(source_config=s3_csv_local_config)
 
@@ -320,7 +320,7 @@ class TestCoreIO:
 
         # # Then
         try:
-            output_df = pd.read_parquet(s3_parquet_local_config["local"]["file_path"])
+            output_df = pd.read_parquet(s3_parquet_local_config.local.file_path)
             assert output_df.columns.to_list() == [
                 "id",
                 "foo_name",
@@ -329,7 +329,7 @@ class TestCoreIO:
                 "event_type",
             ]
         finally:
-            os.remove(s3_parquet_local_config["local"]["file_path"])
+            os.remove(s3_parquet_local_config.local.file_path)
 
     @pytest.mark.unit
     @patch.object(dynamicio.core.DynamicDataIO, "validate_from_schema")
@@ -382,7 +382,7 @@ class TestCoreIO:
         try:
             mock_validate_from_schema.assert_called()
         finally:
-            os.remove(s3_csv_local_config["local"]["file_path"])
+            os.remove(s3_csv_local_config.local.file_path)
 
     @pytest.mark.unit
     @patch.object(dynamicio.core.DynamicDataIO, "validate_from_schema")
@@ -403,7 +403,7 @@ class TestCoreIO:
         try:
             mock_validate_from_schema.assert_not_called()
         finally:
-            os.remove(s3_csv_local_config["local"]["file_path"])
+            os.remove(s3_csv_local_config.local.file_path)
 
     @pytest.mark.unit
     @patch.object(dynamicio.core.DynamicDataIO, "log_metrics_from_schema")
@@ -456,7 +456,7 @@ class TestCoreIO:
         try:
             mock_log_metrics_from_schema.assert_called()
         finally:
-            os.remove(s3_csv_local_config["local"]["file_path"])
+            os.remove(s3_csv_local_config.local.file_path)
 
     @pytest.mark.unit
     @patch.object(dynamicio.core.DynamicDataIO, "log_metrics_from_schema")
@@ -477,7 +477,7 @@ class TestCoreIO:
         try:
             mock_log_metrics_from_schema.assert_not_called()
         finally:
-            os.remove(s3_csv_local_config["local"]["file_path"])
+            os.remove(s3_csv_local_config.local.file_path)
 
     @pytest.mark.unit
     @pytest.mark.parametrize(
@@ -526,9 +526,9 @@ class TestCoreIO:
         try:
             if caplog.messages:
                 assert caplog.messages[0] == expected_warning
-            assert pd.read_parquet(s3_parquet_with_some_bool_col_local_config["local"]["file_path"])["bool_col"].dtype.name == expected_dtype
+            assert pd.read_parquet(s3_parquet_with_some_bool_col_local_config.local.file_path)["bool_col"].dtype.name == expected_dtype
         finally:
-            os.remove(s3_parquet_with_some_bool_col_local_config["local"]["file_path"])
+            os.remove(s3_parquet_with_some_bool_col_local_config.local.file_path)
 
     @pytest.mark.unit
     @pytest.mark.parametrize(
@@ -588,9 +588,9 @@ class TestCoreIO:
         try:
             if caplog.messages:
                 assert caplog.messages[0] == expected_warning
-            assert pd.read_csv(s3_csv_with_some_bool_col_local_config["local"]["file_path"])["bool_col"].dtype.name == expected_dtype
+            assert pd.read_csv(s3_csv_with_some_bool_col_local_config.local.file_path)["bool_col"].dtype.name == expected_dtype
         finally:
-            os.remove(s3_csv_with_some_bool_col_local_config["local"]["file_path"])
+            os.remove(s3_csv_with_some_bool_col_local_config.local.file_path)
 
     @pytest.mark.unit
     @pytest.mark.parametrize(
@@ -650,9 +650,9 @@ class TestCoreIO:
         try:
             if caplog.messages:
                 assert caplog.messages[0] == expected_warning
-            assert pd.read_hdf(s3_hdf_with_some_bool_col_local_config["local"]["file_path"])["bool_col"].dtype.name == expected_dtype
+            assert pd.read_hdf(s3_hdf_with_some_bool_col_local_config.local.file_path)["bool_col"].dtype.name == expected_dtype
         finally:
-            os.remove(s3_hdf_with_some_bool_col_local_config["local"]["file_path"])
+            os.remove(s3_hdf_with_some_bool_col_local_config.local.file_path)
 
     @pytest.mark.unit
     @pytest.mark.parametrize(
@@ -715,9 +715,9 @@ class TestCoreIO:
         try:
             if caplog.messages:
                 assert caplog.messages[0] == expected_warning
-            assert pd.read_json(s3_json_with_some_bool_col_local_config["local"]["file_path"])["bool_col"].dtype.name == expected_dtype
+            assert pd.read_json(s3_json_with_some_bool_col_local_config.local.file_path)["bool_col"].dtype.name == expected_dtype
         finally:
-            os.remove(s3_json_with_some_bool_col_local_config["local"]["file_path"])
+            os.remove(s3_json_with_some_bool_col_local_config.local.file_path)
 
     @pytest.mark.unit
     @pytest.mark.parametrize(
@@ -766,9 +766,9 @@ class TestCoreIO:
 
         # Then
         try:
-            pd.testing.assert_frame_equal(pd.read_parquet(s3_parquet_with_some_bool_col_local_config["local"]["file_path"]), df)
+            pd.testing.assert_frame_equal(pd.read_parquet(s3_parquet_with_some_bool_col_local_config.local.file_path), df)
         finally:
-            os.remove(s3_parquet_with_some_bool_col_local_config["local"]["file_path"])
+            os.remove(s3_parquet_with_some_bool_col_local_config.local.file_path)
 
     @pytest.mark.integration
     def test_show_casting_warnings_flag_default_value_prevents_showing_casting_logs(self, caplog):

--- a/tests/test_mixins/test_local_mixins.py
+++ b/tests/test_mixins/test_local_mixins.py
@@ -298,9 +298,9 @@ class TestLocalIO:
 
         # Then
         try:
-            assert os.path.isfile(pg_parquet_local_config["local"]["file_path"])
+            assert os.path.isfile(pg_parquet_local_config.local.file_path)
         finally:
-            os.remove(pg_parquet_local_config["local"]["file_path"])
+            os.remove(pg_parquet_local_config.local.file_path)
 
     @pytest.mark.unit
     def test_a_df_is_written_locally_as_csv_when_io_config_is_initialised_with_local_env_value_and_csv_file_type(
@@ -320,9 +320,9 @@ class TestLocalIO:
 
         # Then
         try:
-            assert os.path.isfile(s3_csv_local_config["local"]["file_path"])
+            assert os.path.isfile(s3_csv_local_config.local.file_path)
         finally:
-            os.remove(s3_csv_local_config["local"]["file_path"])
+            os.remove(s3_csv_local_config.local.file_path)
 
     @pytest.mark.unit
     def test_a_df_is_written_locally_as_json_when_io_config_is_initialised_with_local_env_value_and_json_file_type(self, input_messages_df):
@@ -340,9 +340,9 @@ class TestLocalIO:
 
         # Then
         try:
-            assert os.path.isfile(kafka_json_local_config["local"]["file_path"])
+            assert os.path.isfile(kafka_json_local_config.local.file_path)
         finally:
-            os.remove(kafka_json_local_config["local"]["file_path"])
+            os.remove(kafka_json_local_config.local.file_path)
 
     @pytest.mark.unit
     def test_a_df_is_written_locally_as_h5_when_io_config_is_initialised_with_local_env_value_and_hdf_file_type(
@@ -362,9 +362,9 @@ class TestLocalIO:
 
         # Then
         try:
-            assert os.path.isfile(s3_hdf_local_config["local"]["file_path"])
+            assert os.path.isfile(s3_hdf_local_config.local.file_path)
         finally:
-            os.remove(s3_hdf_local_config["local"]["file_path"])
+            os.remove(s3_hdf_local_config.local.file_path)
 
     @pytest.mark.unit
     def test_dynamicio_default_pickle_protocol_is_4(
@@ -384,9 +384,9 @@ class TestLocalIO:
 
         # Then
         try:
-            assert max_pklproto_hdf(s3_hdf_local_config["local"]["file_path"]) == 4
+            assert max_pklproto_hdf(s3_hdf_local_config.local.file_path) == 4
         finally:
-            os.remove(s3_hdf_local_config["local"]["file_path"])
+            os.remove(s3_hdf_local_config.local.file_path)
 
     @pytest.mark.unit
     def test_dynamicio_default_pickle_protocol_is_bypassed_by_user_input(
@@ -406,9 +406,9 @@ class TestLocalIO:
 
         # Then
         try:
-            assert max_pklproto_hdf(s3_hdf_local_config["local"]["file_path"]) == 5
+            assert max_pklproto_hdf(s3_hdf_local_config.local.file_path) == 5
         finally:
-            os.remove(s3_hdf_local_config["local"]["file_path"])
+            os.remove(s3_hdf_local_config.local.file_path)
 
     @pytest.mark.unit
     def test_read_resolves_file_path_if_templated_for_some_input_data(self):
@@ -426,7 +426,7 @@ class TestLocalIO:
             io_object.read()
 
         mocked__read_csv_file.assert_called_once_with(
-            config["local"]["file_path"].format(file_name_to_replace="some_csv_to_read"),
+            config.local.file_path.format(file_name_to_replace="some_csv_to_read"),
             io_object.schema,
         )
 
@@ -445,10 +445,10 @@ class TestLocalIO:
         with patch.object(io_object, "_write_csv_file") as mocked__write_csv_file:
             io_object.write(df)
 
-        mocked__write_csv_file.assert_called_once_with(
-            df,
-            config["local"]["file_path"].format(file_name_to_replace="some_csv_to_read"),
-        )
+        mocked__write_csv_file.assert_called_once()
+        (called_with_df, called_with_file_path) = mocked__write_csv_file.call_args[0]
+        pd.testing.assert_frame_equal(df, called_with_df)
+        assert called_with_file_path == config.local.file_path.format(file_name_to_replace="some_csv_to_read")
 
     @pytest.mark.integration
     def test_local_writers_only_write_out_castable_columns_according_to_the_io_schema_case_float64_to_int64_id(
@@ -477,13 +477,13 @@ class TestLocalIO:
 
         # # Then
         try:
-            output_df = pd.read_parquet(s3_parquet_local_config["local"]["file_path"])
+            output_df = pd.read_parquet(s3_parquet_local_config.local.file_path)
             assert list(output_df.dtypes) == [
                 np.dtype("int64"),
                 np.dtype("O"),
             ]  # order of the list matters
         finally:
-            os.remove(s3_parquet_local_config["local"]["file_path"])
+            os.remove(s3_parquet_local_config.local.file_path)
 
     @pytest.mark.integration
     def test_local_writers_only_write_out_columns_in_a_provided_io_schema(self):
@@ -509,13 +509,12 @@ class TestLocalIO:
 
         # Then
         try:
-            output_df = pd.read_parquet(s3_parquet_local_config["local"]["file_path"])
+            output_df = pd.read_parquet(s3_parquet_local_config.local.file_path)
             no_of_columns_of_output_df = len(list(output_df.columns))
             no_of_columns_of_input_df = len(list(input_df.columns))
-
-            assert (no_of_columns_of_input_df - no_of_columns_of_output_df == 1) and (set(output_df.columns) == {*write_s3_io.schema})  # pylint: disable=no-member
+            assert (no_of_columns_of_input_df - no_of_columns_of_output_df == 1) and (set(output_df.columns) == {*write_s3_io.schema.columns.keys()})  # pylint: disable=no-member
         finally:
-            os.remove(s3_parquet_local_config["local"]["file_path"])
+            os.remove(s3_parquet_local_config.local.file_path)
 
     @pytest.mark.unit
     def test_pyarrow_is_used_as_backend_parquet(self):
@@ -569,7 +568,7 @@ class TestLocalIO:
         # When
         ReadFromBatchLocalParquet(config, **read_parquet_kwargs).read()
         # Then
-        mock__read_parquet.assert_called_once_with(config["local"]["file_path"], columns=["id", "foo_name", "bar"], **read_parquet_kwargs)
+        mock__read_parquet.assert_called_once_with(config.local.file_path, columns=["id", "foo_name", "bar"], **read_parquet_kwargs)
 
     @pytest.mark.unit
     def test_read_with_pyarrow_is_called_as_default_when_no_engine_option_is_provided(self):
@@ -585,7 +584,7 @@ class TestLocalIO:
             ReadS3ParquetIO(config).read()
 
         # Then
-        mocked__read_with_pyarrow.assert_called_once_with(config["local"]["file_path"], columns=["id", "foo_name", "bar"])
+        mocked__read_with_pyarrow.assert_called_once_with(config.local.file_path, columns=["id", "foo_name", "bar"])
 
     @pytest.mark.unit
     def test_read_with_pyarrow_is_called_when_engine_option_is_set_to_pyarrow(self):
@@ -601,7 +600,7 @@ class TestLocalIO:
             ReadS3ParquetIO(config, engine="pyarrow").read()
 
         # Then
-        mocked__read_with_pyarrow.assert_called_once_with(config["local"]["file_path"], engine="pyarrow", columns=["id", "foo_name", "bar"])
+        mocked__read_with_pyarrow.assert_called_once_with(config.local.file_path, engine="pyarrow", columns=["id", "foo_name", "bar"])
 
     @pytest.mark.unit
     def test_read_with_fastparquet_is_called_when_engine_option_is_set_to_fastparquet(self):
@@ -617,7 +616,7 @@ class TestLocalIO:
             ReadS3ParquetIO(config, engine="fastparquet").read()
 
         # Then
-        mocked__read_with_fastparquet.assert_called_once_with(config["local"]["file_path"], engine="fastparquet", columns=["id", "foo_name", "bar"])
+        mocked__read_with_fastparquet.assert_called_once_with(config.local.file_path, engine="fastparquet", columns=["id", "foo_name", "bar"])
 
     @pytest.mark.unit
     def test_write_with_pyarrow_is_called_as_default_when_no_engine_option_is_provided(self):

--- a/tests/test_mixins/test_postgres_mixins.py
+++ b/tests/test_mixins/test_postgres_mixins.py
@@ -85,7 +85,9 @@ class TestPostgresIO:
         write_config.write(df)
 
         # Then
-        mock__write_to_postgres.assert_called_with(test_df)
+        mock__write_to_postgres.assert_called_once()
+        (called_with_df, ) = mock__write_to_postgres.call_args[0]
+        pd.testing.assert_frame_equal(test_df, called_with_df)
         assert "truncate_and_append" in write_config.options
 
     @pytest.mark.unit
@@ -161,12 +163,12 @@ class TestPostgresIO:
         ).get(source_key="READ_FROM_POSTGRES")
 
         # When
-        schema = postgres_cloud_config["schema"]
-        schema_name = postgres_cloud_config["name"]
-        model = ReadPostgresIO(source_config=postgres_cloud_config)._generate_model_from_schema(schema, schema_name)
+        schema = postgres_cloud_config.dynamicio_schema
+        schema_name = postgres_cloud_config.dynamicio_schema.name
+        model = ReadPostgresIO(source_config=postgres_cloud_config)._generate_model_from_schema(schema)
 
         # Then
-        assert len(model.__table__.columns) == len(schema) and model.__tablename__ == schema_name
+        assert len(model.__table__.columns) == len(schema.columns) and model.__tablename__ == schema_name
 
     @pytest.mark.unit
     def test_get_table_columns_from_generated_model_returns_valid_list_of_columns(self):
@@ -178,9 +180,8 @@ class TestPostgresIO:
         ).get(source_key="READ_FROM_POSTGRES")
 
         # When
-        schema = pg_cloud_config["schema"]
-        schema_name = pg_cloud_config["name"]
-        model = ReadPostgresIO(source_config=pg_cloud_config)._generate_model_from_schema(schema, schema_name)  # pylint: disable=protected-access
+        schema = pg_cloud_config.dynamicio_schema
+        model = ReadPostgresIO(source_config=pg_cloud_config)._generate_model_from_schema(schema)  # pylint: disable=protected-access
         columns = ReadPostgresIO(source_config=pg_cloud_config)._get_table_columns(model)  # pylint: disable=protected-access
 
         # Then

--- a/tests/test_mixins/test_postgres_mixins.py
+++ b/tests/test_mixins/test_postgres_mixins.py
@@ -86,7 +86,7 @@ class TestPostgresIO:
 
         # Then
         mock__write_to_postgres.assert_called_once()
-        (called_with_df, ) = mock__write_to_postgres.call_args[0]
+        (called_with_df,) = mock__write_to_postgres.call_args[0]
         pd.testing.assert_frame_equal(test_df, called_with_df)
         assert "truncate_and_append" in write_config.options
 

--- a/tests/test_regressions/conftest.py
+++ b/tests/test_regressions/conftest.py
@@ -1,0 +1,26 @@
+import pathlib
+import imp
+
+import pytest
+
+
+@pytest.fixture
+def regressions_resources_dir() -> pathlib.Path:
+    return (pathlib.Path(__file__).parent / "resources").resolve()
+
+
+@pytest.fixture
+def tests_resources_dir(regressions_resources_dir):
+    return regressions_resources_dir.parent.parent / "resources"
+
+
+@pytest.fixture
+def regressions_constants_module(regressions_resources_dir, tests_resources_dir):
+    mod = imp.new_module("regressions_constants_module")
+    mod.__dict__.update(
+        {
+            "REGRESSIONS_RESOURCES_DIR": str(regressions_resources_dir),
+            "TEST_RESOURCES_DIR": str(tests_resources_dir),
+        }
+    )
+    return mod

--- a/tests/test_regressions/conftest.py
+++ b/tests/test_regressions/conftest.py
@@ -1,5 +1,5 @@
-import pathlib
 import imp
+import pathlib
 
 import pytest
 

--- a/tests/test_regressions/resources/missing_v430_validations.yaml
+++ b/tests/test_regressions/resources/missing_v430_validations.yaml
@@ -1,0 +1,13 @@
+PRODUCTS:
+  LOCAL:
+    type: "local"
+    local:
+      file_path: "[[ TEST_RESOURCES_DIR ]]/data/input/some_csv_to_read.csv"
+      file_type: "csv"
+  schema:
+    name: products
+    columns:
+      id:
+        type: "object"
+        validations: {}
+        metrics: []

--- a/tests/test_regressions/test_v430.py
+++ b/tests/test_regressions/test_v430.py
@@ -1,0 +1,26 @@
+"""Test regressions discovered in v4.3.0 release"""
+
+from dynamicio import UnifiedIO
+from dynamicio.core import SCHEMA_FROM_FILE
+from dynamicio.config import IOConfig
+
+
+class IO(UnifiedIO):
+    schema = SCHEMA_FROM_FILE
+
+
+def test_missing_validations_and_metrics(regressions_resources_dir, regressions_constants_module):
+    """Dynamicio was refusing to work with schemas that did not have any validations specified."""
+    # Given
+    input_config = IOConfig(
+        path_to_source_yaml=regressions_resources_dir / "missing_v430_validations.yaml",
+        env_identifier="LOCAL",
+        dynamic_vars=regressions_constants_module,
+    )
+    io_instance = IO(source_config=input_config.get(source_key="PRODUCTS"), apply_schema_validations=True, log_schema_metrics=True)
+
+    # When
+    data = io_instance.read()
+
+    # Then
+    assert data.to_dict() == {"id": {0: 1, 1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15}}

--- a/tests/test_regressions/test_v430.py
+++ b/tests/test_regressions/test_v430.py
@@ -1,8 +1,8 @@
 """Test regressions discovered in v4.3.0 release"""
 
 from dynamicio import UnifiedIO
-from dynamicio.core import SCHEMA_FROM_FILE
 from dynamicio.config import IOConfig
+from dynamicio.core import SCHEMA_FROM_FILE
 
 
 class IO(UnifiedIO):


### PR DESCRIPTION
## Overview

Changing internal dynamicio config file processing from using freeform dicts to `pydantic`.

## Key Changes

The internal configuration storage is changing from freeform dicts to `pydantic` classes.  

If you are accessing config objects internals for testing, you will have to change any `config.get(<>)["local"]["file_path"]` calls to `config.get(<>).local.file_path`

## Impact

* The unexpected configuration parameters will be immediately reported to the user
* Python type hints now work for configuration objects 
