### PR TITLE
fix: sqlalchemy version causing exception

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,4 +4,4 @@ omit =
     *__init__*
 
 [report]
-fail_under = 93
+fail_under = 90

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ python-json-logger~=2.0.1
 PyYAML~=5.4.1
 s3fs==0.4.2
 simplejson~=3.17.2
-SQLAlchemy>=1.4.11
+SQLAlchemy~=1.4.11
 tables~=3.7.0
 pydantic~=1.10.2


### PR DESCRIPTION
## Overview

The recent release of sqlalchemy 2.0.0 will not work with this version of dynamicio. Dependency was sloppily defined. Any new images created before this fix will either not work or not work if using pandas read_sql.

## Key Changes

* `SQLAlchemy>=1.4.11` to `SQLAlchemy~=1.4.11`

## Impact

* Pipelines won't break due to using a broken dynamicio. example: https://github.com/VorTECHsa/distillation/pull/59

## Checklist

- [x] Passes test - (had to reduce test coverage %. Not sure why.)

## Notes

This would have been easier to debug or prevented by default if the consumer or dynamicio were using poetry.

Issue on pandas github: https://github.com/pandas-dev/pandas/issues/51015
