### PR TITLE
feat: Adding '---' to the beginning of yaml files generated by cli

### DIFF
--- a/dynamicio/cli.py
+++ b/dynamicio/cli.py
@@ -88,11 +88,13 @@ def main(args: argparse.Namespace):
                 print(f"Skipping {exception.message}! You may want to remove this file from the datasets directory")
             else:
                 with open(os.path.join(args.output, f"{json_schema['name']}.yaml"), "w") as yml:  # pylint: disable=unspecified-encoding]
+                    yml.write("---\n")
                     yaml.safe_dump(json_schema, yml)
 
     if args.single:
         json_schema = generate_schema_for(str(args.path))
         with open(os.path.join(args.output, f"{json_schema['name']}.yaml"), "w") as yml:  # pylint: disable=unspecified-encoding]
+            yml.write("---\n")
             yaml.safe_dump(json_schema, yml)
         pprint.pprint(json_schema)
 

--- a/dynamicio/cli.py
+++ b/dynamicio/cli.py
@@ -87,15 +87,15 @@ def main(args: argparse.Namespace):
             except InvalidDatasetTypeError as exception:
                 print(f"Skipping {exception.message}! You may want to remove this file from the datasets directory")
             else:
-                with open(os.path.join(args.output, f"{json_schema['name']}.yaml"), "w") as yml:  # pylint: disable=unspecified-encoding]
-                    yml.write("---\n")
-                    yaml.safe_dump(json_schema, yml)
+                with open(os.path.join(args.output, f"{json_schema['name']}.yaml"), "w") as file:  # pylint: disable=unspecified-encoding]
+                    file.write("---\n")
+                    yaml.safe_dump(json_schema, file)
 
     if args.single:
         json_schema = generate_schema_for(str(args.path))
-        with open(os.path.join(args.output, f"{json_schema['name']}.yaml"), "w") as yml:  # pylint: disable=unspecified-encoding]
-            yml.write("---\n")
-            yaml.safe_dump(json_schema, yml)
+        with open(os.path.join(args.output, f"{json_schema['name']}.yaml"), "w") as file:  # pylint: disable=unspecified-encoding]
+            file.write("---\n")
+            yaml.safe_dump(json_schema, file)
         pprint.pprint(json_schema)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ class DummyYaml:
         return f"DummyYaml({self.path!r})"
 
     def __enter__(self):
-        return Mock(), None
+        return Mock()
 
     def __exit__(self, *args):
         return None


### PR DESCRIPTION
## Overview

Current CLI tool generated schemas dont adhere to the yamllint convention of starting the file with '---' 
This fixes it.

## Key Changes

Added a line to write '---' at the beginning of yaml files

Tested locally