### PR TITLE
feat: support specifying a subset of fields to read

### DIFF
--- a/dynamicio/config/pydantic/__init__.py
+++ b/dynamicio/config/pydantic/__init__.py
@@ -10,4 +10,4 @@ from dynamicio.config.pydantic.io_resources import (
     S3DataEnvironment,
     S3PathPrefixEnvironment,
 )
-from dynamicio.config.pydantic.table_schema import DataframeSchema
+from dynamicio.config.pydantic.table_schema import DataframeSchema, SchemaColumn

--- a/dynamicio/core.py
+++ b/dynamicio/core.py
@@ -6,14 +6,14 @@ import asyncio
 import inspect
 import re
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Mapping, MutableMapping, Optional
+from typing import Any, List, Mapping, MutableMapping, Optional, Tuple
 
 import pandas as pd  # type: ignore
 import pydantic
 from magic_logger import logger
 
 from dynamicio import validations
-from dynamicio.config.pydantic import DataframeSchema, IOEnvironment
+from dynamicio.config.pydantic import DataframeSchema, IOEnvironment, SchemaColumn
 from dynamicio.errors import CASTING_WARNING_MSG, ColumnsDataTypeError, NOTICE_MSG, SchemaNotFoundError, SchemaValidationError
 from dynamicio.metrics import get_metric
 
@@ -278,13 +278,13 @@ class DynamicDataIO:
             bool - `True` if `df` has the given dtypes, `False` otherwise
         """
         dtypes = df.dtypes
-        cols_to_validate = [self.schema.columns[c] for c in self.options.get("columns", self.schema.column_names) if c in self.schema.column_names]
 
-        if len(cols_to_validate) < len(self.options.get("columns", [])):
-            logger.exception(f"Some of the columns passed {self.options['columns']} do not belong to the schema")
+        cols_allowed, cols_not_allowed = self._split_columns_to_validate_between_allowed_and_not(columns_to_validate=self.options.get("columns", self.schema.column_names))
+        if cols_not_allowed:
+            logger.exception(f"The columns passed: {cols_not_allowed} do not belong to the schema")
             return False
 
-        for col_info in cols_to_validate:
+        for col_info in cols_allowed:
             column_name = col_info.name
             expected_dtype = col_info.data_type
             found_dtype = dtypes[column_name].name
@@ -300,6 +300,16 @@ class DynamicDataIO:
                     logger.exception(f"ValueError: Tried casting column {self.name}['{column_name}'] to '{expected_dtype}' from '{found_dtype}', but failed")
                     return False
         return True
+
+    def _split_columns_to_validate_between_allowed_and_not(self, columns_to_validate: List[str]) -> Tuple[List[SchemaColumn], List[str]]:
+        not_allowed_cols, allowed_cols = [], []
+        for col in columns_to_validate:
+            col_from_schema = self.schema.columns.get(col)
+            if col_from_schema:
+                allowed_cols.append(col_from_schema)
+            else:
+                not_allowed_cols.append(col)
+        return allowed_cols, not_allowed_cols
 
     @staticmethod
     def _get_options(options_from_code: MutableMapping[str, Any], options_from_resource_definition: Optional[Mapping[str, Any]]) -> MutableMapping[str, Any]:

--- a/dynamicio/core.py
+++ b/dynamicio/core.py
@@ -278,8 +278,13 @@ class DynamicDataIO:
             bool - `True` if `df` has the given dtypes, `False` otherwise
         """
         dtypes = df.dtypes
+        cols_to_validate = [self.schema.columns[c] for c in self.options.get("columns", self.schema.column_names) if c in self.schema.column_names]
 
-        for col_info in self.schema.columns.values():
+        if len(cols_to_validate) < len(self.options.get("columns", [])):
+            logger.exception(f"Some of the columns passed {self.options['columns']} do not belong to the schema")
+            return False
+
+        for col_info in cols_to_validate:
             column_name = col_info.name
             expected_dtype = col_info.data_type
             found_dtype = dtypes[column_name].name

--- a/dynamicio/mixins/with_local.py
+++ b/dynamicio/mixins/with_local.py
@@ -137,7 +137,7 @@ class WithLocal:
         Returns:
             DataFrame: The dataframe read from the parquet file.
         """
-        options["columns"] = list(schema.column_names)
+        options["columns"] = options.get("columns", list(schema.column_names))
 
         if options.get("engine") == "fastparquet":
             return WithLocal.__read_with_fastparquet(file_path, **options)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 
 from dynamicio import WithS3PathPrefix
+from dynamicio.config import IOConfig
 from tests import constants
 from tests.mocking.models import ERModel
 
@@ -911,3 +912,12 @@ def mock_parquet_temporary_directory_w_empty_files():
     with patch.object(tempfile, "TemporaryDirectory") as mock:
         mock.return_value.__enter__.return_value = os.path.join(constants.TEST_RESOURCES, "data/input/batch/parquet_w_empty_files")
         yield mock
+
+
+@pytest.fixture
+def s3_parquet_local_config():
+    return IOConfig(
+        path_to_source_yaml=(os.path.join(constants.TEST_RESOURCES, "definitions/input.yaml")),
+        env_identifier="LOCAL",
+        dynamic_vars=constants,
+    ).get(source_key="S3_PARQUET_WITH_OPTIONS_IN_CODE")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -786,26 +786,42 @@ class TestCoreIO:
     @pytest.mark.unit
     def test_columns_options_is_passed_to_parquet_read(self, s3_parquet_local_config):
         with patch("dynamicio.mixins.with_local.pd.read_parquet") as mocked_call:
+            # Given
             reader = ReadS3ParquetIO(source_config=s3_parquet_local_config, columns=["bar"])
+
+            # When
             reader.read()
             kwargs_values = mocked_call.call_args.kwargs
+
+            # Then
             assert "columns" in kwargs_values
             assert kwargs_values["columns"] == ["bar"]
 
     @pytest.mark.unit
     def test_schema_columns_are_used_as_default_in_parquet_read(self, s3_parquet_local_config):
         with patch("dynamicio.mixins.with_local.pd.read_parquet") as mocked_call:
+            # Given
             reader = ReadS3ParquetIO(source_config=s3_parquet_local_config)
+
+            # When
             reader.read()
             kwargs_values = mocked_call.call_args.kwargs
+
+            # Then
             assert "columns" in kwargs_values
             assert kwargs_values["columns"] == ["id", "foo_name", "bar"]
 
     @pytest.mark.unit
     def test_columns_options_with_names_missing_from_schema_fails(self, s3_parquet_local_config):
         with patch("dynamicio.mixins.with_local.pd.read_parquet"):
+
+            # Given
             reader = ReadS3ParquetIO(source_config=s3_parquet_local_config, columns=["bar", "column_missing_from_schema"])
+
+            # When
             with pytest.raises(ColumnsDataTypeError):
+
+                # Then
                 reader.read()
 
     @pytest.mark.unit

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -776,20 +776,37 @@ class TestCoreIO:
         assert getattr(caplog.records[0], "message") == "Expected: 'float64' dtype for READ_S3_DATA_WITH_FALSE_TYPES['id]', found 'int64'"
 
     @pytest.mark.unit
-    def test_options_are_read_from_code(self):
-
-        # Given
-        s3_parquet_local_config = IOConfig(
-            path_to_source_yaml=(os.path.join(constants.TEST_RESOURCES, "definitions/input.yaml")),
-            env_identifier="LOCAL",
-            dynamic_vars=constants,
-        ).get(source_key="S3_PARQUET_WITH_OPTIONS_IN_CODE")
-
+    def test_options_are_read_from_code(self, s3_parquet_local_config):
         # When
         config_io = ReadS3ParquetIO(source_config=s3_parquet_local_config, option_1=False, option_2=True)
 
         # Then
         assert config_io.options == {"option_1": False, "option_2": True}
+
+    @pytest.mark.unit
+    def test_columns_options_is_passed_to_parquet_read(self, s3_parquet_local_config):
+        with patch("dynamicio.mixins.with_local.pd.read_parquet") as mocked_call:
+            reader = ReadS3ParquetIO(source_config=s3_parquet_local_config, columns=["bar"])
+            reader.read()
+            kwargs_values = mocked_call.call_args.kwargs
+            assert "columns" in kwargs_values
+            assert kwargs_values["columns"] == ["bar"]
+
+    @pytest.mark.unit
+    def test_schema_columns_are_used_as_default_in_parquet_read(self, s3_parquet_local_config):
+        with patch("dynamicio.mixins.with_local.pd.read_parquet") as mocked_call:
+            reader = ReadS3ParquetIO(source_config=s3_parquet_local_config)
+            reader.read()
+            kwargs_values = mocked_call.call_args.kwargs
+            assert "columns" in kwargs_values
+            assert kwargs_values["columns"] == ["id", "foo_name", "bar"]
+
+    @pytest.mark.unit
+    def test_columns_options_with_names_missing_from_schema_fails(self, s3_parquet_local_config):
+        with patch("dynamicio.mixins.with_local.pd.read_parquet"):
+            reader = ReadS3ParquetIO(source_config=s3_parquet_local_config, columns=["bar", "column_missing_from_schema"])
+            with pytest.raises(ColumnsDataTypeError):
+                reader.read()
 
     @pytest.mark.unit
     def test_options_are_read_from_resource_definition(self):


### PR DESCRIPTION
Being able to specify a subset of fields to read and only read these is a particularly useful feature. In particular when reading data stored in parquet files, where it is possible to read only the data needed, rather than all of all the time and then remove the one not needed.

## Key Changes

If a subset of fields is specified whenever the IO resources is initialised schema validation is going to be performed only on these fields

## Impact

* introduce a backward compatible feature

## Checklist

The following won't apply in all cases - mark `N/A` next to point if not needed.

- [ ] Module, function, class docstrings updated
- [ ] Interface documentation updated
- [ ] Semantic commits used for this PR, so that a CHANGELOG can be generated from them (don't delete your local branch! when tagging a new release from master)

## Release-Steps

- [ ] Merge PR
- [ ] Release new tag
