### PR TITLE
feat: Label Postgres connections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ create-jupyter-kernel:
 
 run-tests:
 	@python -m pytest --cache-clear --cov=${CODE_DIR} ${TESTS}
-	@python -m pytest --cache-clear --cov=demo/src demo/tests
 
 run-unit-tests:
 	@python -m pytest -v -m unit ${TESTS}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pandas~=1.2
 psycopg2-binary~=2.9.3
 pyarrow>=7.0.0
 python-json-logger~=2.0.1
-PyYAML~=5.4.1
+PyYAML>=5.4.1
 s3fs==0.4.2
 simplejson~=3.17.2
 SQLAlchemy~=1.4.11


### PR DESCRIPTION
## Overview

DST wants us to label our postgress connections so they can know which application might be messing stuff up ;) 
This PR adds an option for dynamicio users to pass in an application name in their resource configuration so that we can keep track of our postgress connections 
## Key Changes

* Added abc to `foo.py`
* Fixed bug in `buggy_function` in `bar.py`


## Checklist

The following won't apply in all cases - mark `N/A` next to point if not needed.

- [X] Appropriate unit tests added/updated
- [X] Module, function, class docstrings updated
- [X] Comments added to PR where necessary
- [X] Interface documentation updated
- [X] Semantic commits used for this PR, so that a CHANGELOG can be generated from them (don't delete your local branch! when tagging a new release from master)

## Release-Steps

- [ ] Merge PR
- [ ] Release new tag
