### PR TITLE
new pydantic

### DIFF
--- a/dynamicio/config/pydantic/io_resources.py
+++ b/dynamicio/config/pydantic/io_resources.py
@@ -41,7 +41,10 @@ class IOBinding(pydantic.BaseModel):
     """A binding for a single i/o object"""
 
     name: str = pydantic.Field(alias="__binding_name__")
-    environments: Mapping[str, "IOEnvironment"]
+    environments: Mapping[
+        str,
+        Union["IOEnvironment", "LocalDataEnvironment", "LocalBatchDataEnvironment", "S3DataEnvironment", "S3PathPrefixEnvironment", "KafkaDataEnvironment", "PostgresDataEnvironment"],
+    ]
     dynamicio_schema: Union[table_spec.DataframeSchema, None] = pydantic.Field(default=None, alias="schema")
 
     def get_binding_for_environment(self, environment: str) -> "IOEnvironment":
@@ -217,4 +220,4 @@ class PostgresDataEnvironment(IOEnvironment):
     postgres: PostgresDataSubSection
 
 
-IOBinding.update_forward_refs()
+IOBinding.model_rebuild()

--- a/dynamicio/config/pydantic/io_resources.py
+++ b/dynamicio/config/pydantic/io_resources.py
@@ -49,10 +49,10 @@ class IOBinding(pydantic.BaseModel):
         return self.environments[environment]
 
     @pydantic.validator("environments", pre=True, always=True)
-    def pick_correct_env_cls(cls, value, values, config, field):
+    def pick_correct_env_cls(cls, info):
         """This pre-validator picks an appropriate IOEnvironment subclass for the `data_backend_type`"""
-        if not isinstance(value, Mapping):
-            raise ValueError(f"Environments input should be a dict. Got {value!r} instead.")
+        if not isinstance(info, Mapping):
+            raise ValueError(f"Environments input should be a dict. Got {info!r} instead.")
         config_cls_overrides = {
             DataBackendType.local: LocalDataEnvironment,
             DataBackendType.local_batch: LocalBatchDataEnvironment,
@@ -63,8 +63,8 @@ class IOBinding(pydantic.BaseModel):
             DataBackendType.postgres: PostgresDataEnvironment,
         }
         out_dict = {}
-        for (env_name, env_data) in value.items():
-            base_obj: IOEnvironment = field.type_(**env_data)
+        for (env_name, env_data) in info.items():
+            base_obj: IOEnvironment = IOEnvironment(**env_data)
             override_cls = config_cls_overrides.get(base_obj.data_backend_type)
             if override_cls:
                 use_obj = override_cls(**env_data)

--- a/dynamicio/config/pydantic/table_schema.py
+++ b/dynamicio/config/pydantic/table_schema.py
@@ -43,7 +43,10 @@ class SchemaColumn(pydantic.BaseModel):
     @pydantic.validator("data_type")
     def is_valid_pandas_type(cls, info):
         """Checks that the data_type is understood by pandas."""
-        pandas_dtype(info)
+        try:
+            pandas_dtype(info)
+        except TypeError:
+            raise ValueError(f"Unexpected data type {info}") from None
         return info
 
     @pydantic.validator("validations", pre=True)
@@ -79,7 +82,7 @@ class DataframeSchema(pydantic.BaseModel):
         """Tell each column its name (the key it is listed under)"""
         if not isinstance(info, Mapping):
             raise ValueError(f"{info!r} shoudl be a dict.")
-        
+
         return {str(col_name): {**{"name": str(col_name)}, **col_data} for (col_name, col_data) in info.items()}
 
     @property

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ s3fs==0.4.2
 simplejson~=3.17.2
 SQLAlchemy~=1.4.11
 tables~=3.0
-pydantic~=2.0
+pydantic>=2.0,<3

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ PyYAML>=5.4.1
 s3fs==0.4.2
 simplejson~=3.17.2
 SQLAlchemy~=1.4.11
-tables~=3.7.0
-pydantic~=1.10.2
+tables~=3.0
+pydantic~=2.0

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 """Packaging and distribution configuration."""
 import os
+import warnings
 
 import setuptools
 
@@ -35,7 +36,8 @@ def get_version():
         with open(VERSION_FILE, "r") as f:
             return f.read().strip()
 
-    raise ValueError("Could not determine build version")
+    warnings.warn("Could not determine build version")
+    return '0.0.0dev0'
 
 
 def read_requirements(file_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,10 @@
 # pylint: disable=missing-module-docstring, missing-class-docstring, missing-function-docstring, R0801
 import io
+import json
 import os
 
 import pytest
 import yaml
-import json
 
 from dynamicio.config.io_config import IOConfig, SafeDynamicResourceLoader, SafeDynamicSchemaLoader
 from tests import constants

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ import os
 
 import pytest
 import yaml
+import json
 
 from dynamicio.config.io_config import IOConfig, SafeDynamicResourceLoader, SafeDynamicSchemaLoader
 from tests import constants
@@ -20,7 +21,7 @@ class TestIOConfig:
         )
 
         # When
-        yaml_dict = input_config.config.dict()
+        yaml_dict = json.loads(input_config.config.model_dump_json())
         # Then
         assert yaml_dict == expected_input_yaml_dict
 


### PR DESCRIPTION
## Overview

This PR bumps the dynamicio v4 to use pydantic v2.

This is required for the dynamicio to be compatible with the new `vtx-mlflow-deploy` and the RC had been tested in the `congestion` projct.

## Key Changes

* pydantic update

## Impact

* pydantic v1 -> v2 change => expect to do some work to upgrade.

## Checklist

The following won't apply in all cases - mark `N/A` next to point if not needed.

- [ ] Semantic commits used for this PR, so that a CHANGELOG can be generated from them (don't delete your local branch! when tagging a new release from master)

## Release-Steps

- [ ] Merge PR
- [ ] Release new tag
