### PR TITLE
refactor: Allow pydantic v1 by using some deprecated functions

### DIFF
--- a/dynamicio/config/pydantic/io_resources.py
+++ b/dynamicio/config/pydantic/io_resources.py
@@ -7,7 +7,7 @@ import posixpath
 from typing import Mapping, Optional, Union
 
 import pydantic
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel
 
 import dynamicio.config.pydantic.table_schema as table_spec
 
@@ -93,7 +93,7 @@ class IOBinding(BaseModel):
 
 
 class IOEnvironment(BaseModel):
-    """A section specifiing an data source backed by a particular data backend."""
+    """A section specifying an data source backed by a particular data backend."""
 
     _parent: Optional[IOBinding] = None  # noqa: F821
     options: Mapping = pydantic.Field(default_factory=dict)
@@ -137,7 +137,7 @@ class LocalBatchDataSubSection(BaseModel):
     dynamic_file_path: Optional[str] = None
     file_type: FileType
 
-    @model_validator(mode="before")
+    @pydantic.root_validator(pre=True)
     def check_path_fields(cls, values):
         """Check that only one of path_prefix or dynamic_file_path is provided & they meet format requirements."""
         path_prefix = values.get("path_prefix")
@@ -188,7 +188,7 @@ class S3PathPrefixSubSection(BaseModel):
     file_type: FileType
     bucket: str
 
-    @model_validator(mode="before")
+    @pydantic.root_validator(pre=True)
     def check_path_fields(cls, values):
         """Check that only one of path_prefix or dynamic_file_path is provided & they meet format requirements."""
         path_prefix = values.get("path_prefix")
@@ -270,4 +270,4 @@ class PostgresDataEnvironment(IOEnvironment):
     postgres: PostgresDataSubSection
 
 
-IOBinding.model_rebuild()
+IOBinding.update_forward_refs()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ no_implicit_optional==1.4.0
 pandas>=1.2.4
 psycopg2-binary~=2.9.3
 pyarrow>=7.0.0
-pydantic>=2.0,<3
+pydantic>=1.9.2,<3
 python-json-logger~=2.0.1
 PyYAML>=5.4.1
 s3fs==0.4.2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-module-docstring, missing-class-docstring, missing-function-docstring, R0801
 import io
-import json
 import os
 
 import pytest
@@ -21,7 +20,7 @@ class TestIOConfig:
         )
 
         # When
-        yaml_dict = json.loads(input_config.config.model_dump_json())
+        yaml_dict = input_config.config.dict()
         # Then
         assert yaml_dict == expected_input_yaml_dict
 


### PR DESCRIPTION
## Overview

Since this is a package it should have the most relaxed requirements possible.

## Key Changes

* Relaxed pydantic constraints
* Using deprecated pydantic functions

## Impact

* Can now use lower pydantic versions

## Checklist

The following won't apply in all cases - mark `N/A` next to point if not needed.

- [ ] Appropriate unit tests added/updated
- [ ] Module, function, class docstrings updated
- [ ] Comments added to PR where necessary
- [ ] Interface documentation updated
- [ ] Semantic commits used for this PR, so that a CHANGELOG can be generated from them (don't delete your local branch! when tagging a new release from master)

## Optional Below:

- [ ] Screenshots of actual interactions with live resources. 
- [ ] Performance stats/graphs.

## Release-Steps

- [x] Merge PR
- [ ] Release new tag
