### PR TITLE
feat: Add new allowed properties to pyarrow-writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,16 +104,18 @@ Quoting from the same paper:
 > An important strategy for combating glue-code is to wrap black-box packages into common API's. This allows supporting
 > infrastructure to be more reusable and reduces the cost of changing packages.
 
-Dynamicio (or dynamic(i/o)) serves exactly that; it serves as a convenient wrapper around `pandas` I/O operations. It's a manifestation of 
-the dependency inversion principle--a layer of indirection if you want--which keeps your code DRY and increases re-usability, effectively 
-decoupling business logic from the I/O layer.
+Dynamicio (or dynamic(i/o)) serves exactly that; it serves as a convenient wrapper around `pandas` I/O operations. It's a manifestation of the dependency inversion principle--a layer of indirection if you want--which keeps your code DRY and increases re-usability, effectively decoupling business logic from the I/O layer.
 
 ### Main features
 `dynamic(i/o)` supports:
-* seamless transition between environments; 
-* abstracting away from resource and data types through `resource definitions`; 
+* seamless transition between environments;
+* abstracting away from resource and data types through `resource definitions`;
 * honouring your expectations on data through `schema definitions`;
-* metrics auto-generation (logging) for monitoring purposes.
+* metrics auto-generation (logging) for monitoring purposes;
+
+#### Extras
+* **PyArrow write dataset enhancements**: Added support for writing Parquet files using PyArrow's dataset functionality, which includes handling large-scale data with `max_partitions` and `max_open_files` for efficient parallel I/O operations.
+
 
 ## Supported sources and data formats
 
@@ -903,6 +905,21 @@ TO_PARQUET_KWARGS = {
     "allow_truncated_timestamps": True,
 }
 ```
+Notice that you can pass all pandas options to write out, when for instance you are writing out parquet.
+
+demo/src/constants.py:
+```python
+# Parquet
+TO_PARQUET_KWARGS = {
+    "use_pyarrow_write": True, # Enable PyArrow writing
+    "use_deprecated_int96_timestamps": False,
+    "coerce_timestamps": "ms",
+    "allow_truncated_timestamps": True,
+    "max_partitions": 2000,  # Enable PyArrow dataset writing with partitioning
+    "max_open_files": 100,   # Control the number of simultaneously open files during write
+}
+```
+The newly added support for PyArrow's write_dataset allows you to manage more advanced configurations, such as partitioning (max_partitions) and limiting the number of open files (max_open_files) when writing Parquet files. This ensures more efficient writes, especially for large datasets, by leveraging PyArrow's parallel writing capabilities.
 
 Of, course this is not a problem as parquet is the format used by both resources in either environment. This not always the case however. See in 
 `demo/resources/definitions/processed.yaml`:

--- a/dynamicio/config/pydantic/io_resources.py
+++ b/dynamicio/config/pydantic/io_resources.py
@@ -10,6 +10,7 @@ import pydantic
 from pydantic import BaseModel
 
 import dynamicio.config.pydantic.table_schema as table_spec
+from dynamicio.errors import ParentNotSetError
 
 
 @enum.unique
@@ -93,22 +94,17 @@ class IOBinding(BaseModel):
 
 
 class IOEnvironment(BaseModel):
-    """A section specifying an data source backed by a particular data backend."""
+    """A section specifying a data source backed by a particular data backend."""
 
     _parent: Optional[IOBinding] = None  # noqa: F821
     options: Mapping = pydantic.Field(default_factory=dict)
     data_backend_type: DataBackendType = pydantic.Field(alias="type", const=None)
 
-    class Config:
-        """Additional pydantic configuration for the model."""
-
-        underscore_attrs_are_private = True
-
     @property
     def dynamicio_schema(self) -> Union[table_spec.DataframeSchema, None]:
         """Returns tabular data structure definition for the data source (if available)."""
         if not self._parent:
-            raise Exception("Parent field is not set.")
+            raise ParentNotSetError("Parent field is not set for this IOEnvironment.")
         return self._parent.dynamicio_schema
 
     def set_parent(self, parent: IOBinding):  # noqa: F821

--- a/dynamicio/errors.py
+++ b/dynamicio/errors.py
@@ -11,6 +11,7 @@ __all__ = [
     "SchemaNotFoundError",
     "SchemaValidationError",
     "InvalidDatasetTypeError",
+    "ParentNotSetError",
     "CASTING_WARNING_MSG",
     "NOTICE_MSG",
 ]
@@ -62,6 +63,13 @@ class MissingSchemaDefinition(DynamicIOError):
 
     ERROR_STR = "The resource definition for this class is missing a schema definition"
     ERROR_STR_DETAILED = "The resource definition for this class is missing a schema definition: {0}"
+
+
+class ParentNotSetError(DynamicIOError):
+    """Error raised when a parent field is not set in an IOEnvironment."""
+
+    ERROR_STR = "Parent field is not set in the IOEnvironment."
+    ERROR_STR_DETAILED = "Parent field is not set in the IOEnvironment for {0}."
 
 
 class DataSourceError(DynamicIOError):

--- a/dynamicio/mixins/utils.py
+++ b/dynamicio/mixins/utils.py
@@ -1,4 +1,4 @@
-"""Mixin utility functions"""
+"""Mixin utility functions."""
 # pylint: disable=no-member, protected-access, too-few-public-methods
 
 import inspect
@@ -21,7 +21,7 @@ def allow_options(options: Union[Iterable, FunctionType, MethodType]):
         read_with_valid_options: The input function called with modified options.
     """
 
-    def _filter_out_irrelevant_options(kwargs: Mapping, valid_options: Iterable):
+    def _filter_out_irrelevant_options(kwargs: Mapping, valid_options: Iterable, func_name: str, file_type: str):
         filtered_options = {}
         invalid_options = {}
         for key_arg in kwargs.keys():
@@ -29,19 +29,19 @@ def allow_options(options: Union[Iterable, FunctionType, MethodType]):
                 filtered_options[key_arg] = kwargs[key_arg]
             else:
                 invalid_options[key_arg] = kwargs[key_arg]
+
         if len(invalid_options) > 0:
             logger.warning(
-                f"Options {invalid_options} were not used because they were not supported by the read or write method configured for this source. "
-                "Check if you expected any of those to have been used by the operation!"
+                f"Options {invalid_options} were not used by the {func_name} method for file type {file_type}. " "Check if you expected any of those to have been used by the operation!"
             )
         return filtered_options
 
     def read_with_valid_options(func):
         @wraps(func)
-        def _(*args, **kwargs):
+        def _(*args, file_type="unknown", **kwargs):
             if callable(options):
-                return func(*args, **_filter_out_irrelevant_options(kwargs, args_of(options)))
-            return func(*args, **_filter_out_irrelevant_options(kwargs, options))
+                return func(*args, **_filter_out_irrelevant_options(kwargs, args_of(options), func.__name__, file_type))
+            return func(*args, **_filter_out_irrelevant_options(kwargs, options, func.__name__, file_type))
 
         return _
 

--- a/dynamicio/mixins/with_local.py
+++ b/dynamicio/mixins/with_local.py
@@ -219,7 +219,7 @@ class WithLocal:
         return WithLocal.__write_with_pyarrow(df, file_path, **options)
 
     @classmethod
-    @utils.allow_options([*utils.args_of(pd.DataFrame.to_parquet), *utils.args_of(write_table)])
+    @utils.allow_options([*utils.args_of(pd.DataFrame.to_parquet), *utils.args_of(write_table), *["max_partitions", "max_open_files"]])
     def __write_with_pyarrow(cls, df: pd.DataFrame, filepath: str, **options: Any):
         return df.to_parquet(filepath, **options)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ s3fs==0.4.2
 simplejson~=3.17.2
 SQLAlchemy~=1.4.11
 tables~=3.0
+numpy<2.0.0


### PR DESCRIPTION
## Overview

Currently, `dynamicio` has a way of confirming whether certain `kwargs` are valid kwargs for the intended I/O process they are used. This is done with the `@allow_options` decorator. 

We recently discovered as this decorator is set up for writing parquet files it ignores two valid `pyarrow` options: `max_partitions` and `max_open_files`. 

```python
    @staticmethod
    def _write_parquet_file(df: pd.DataFrame, file_path: str, **options: Any):
        """Write a dataframe as a parquet file using `df.to_parquet`.

        All `options` are passed directly to `df.to_parquet`.

        Args:
            df: A dataframe write out.
            file_path: The location where the file needs to be written.
            options: Options relative to writing a parquet file.
        """
        if options.get("engine") == "fastparquet":
            return WithLocal.__write_with_fastparquet(df, file_path, **options)
        return WithLocal.__write_with_pyarrow(df, file_path, **options)

    @classmethod
    @utils.allow_options([*utils.args_of(pd.DataFrame.to_parquet), *utils.args_of(write_table)])
    def __write_with_pyarrow(cls, df: pd.DataFrame, filepath: str, **options: Any):
        return df.to_parquet(filepath, **options)

    @classmethod
    @utils.allow_options([*utils.args_of(pd.DataFrame.to_parquet), *utils.args_of(write)])
    def __write_with_fastparquet(cls, df: pd.DataFrame, filepath: str, **options: Any):
        return df.to_parquet(filepath, **options)
```

Both `max_partitions` and `max_open_files` are related to how `pyarrow` writes partitioned Parquet files. These options are not part of the standard options for `pandas.DataFrame.to_parquet` or even `pyarrow.parquet.write_table`. They are environment variables or options handled directly by the pyarrow library, specifically when working with partitioned datasets.

* `max_partitions`:
This controls the maximum number of partitions that can be handled when writing partitioned datasets using the pyarrow engine.

It’s controlled via the environment variable ARROW_MAX_DATASET_PARTITIONS, but there's no direct parameter max_partitions passed to functions like write_table.

* `max_open_files`:
This is an internal option used by pyarrow when working with datasets that involve many open files, such as partitioned datasets. Like max_partitions, this is managed internally by pyarrow rather than as a direct argument to write_table or to_parquet.
Where Do These Options Belong?

`max_partitions` and `max_open_files` are not passed directly to the `pyarrow.parquet.write_table` or `pandas.DataFrame.to_parquet` function calls.
Instead, they are part of the internal workings of the `pyarrow` dataset API, particularly when dealing with partitioned datasets.

## Key Changes

* Allow for the new options to be used upon writing parquet files; 
* Improving logging of allow-options filtering;
* Stop `pydantic` outdated warning on `underscore_attrs_are_private`;

## Impact

* better support of parquet writing; 

## Checklist

The following won't apply in all cases - mark `N/A` next to point if not needed.

- [x] Appropriate unit tests added/updated
- [x] Module, function, class docstrings updated
- [x] Comments added to PR where necessary
- [x] Interface documentation updated
- [x] Semantic commits used for this PR, so that a CHANGELOG can be generated from them (don't delete your local branch! when tagging a new release from master)

## Release-Steps

- [ ] Merge PR
- [ ] Release new tag
