### PR TITLE
build: Downgrade libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ generate-docs:
 
 build-locally:
 	@${VENV_BIN_PATH}/pip install --upgrade build
-	@BUILD_VERSION=7.0.1 ${VENV_BIN_PATH}/python setup.py sdist bdist_wheel # Add a <some_version>, e.g. 0.2.3
+	@BUILD_VERSION=7.1.0 ${VENV_BIN_PATH}/python setup.py sdist bdist_wheel # Add a <some_version>, e.g. 0.2.3
 
 upload-package:
 	@${VENV_BIN_PATH}/pip install --upgrade twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,13 +7,13 @@ logzero>=1.7.0
 magic-logger>=1.0.2
 numpy>=1.24.0, <2.0.0
 no_implicit_optional==1.4.0
-pandas>=1.5.1
+pandas>=1.2.4
 psycopg2-binary~=2.9.3
-pyarrow>=10.0.1
+pyarrow>=7.0.0
 pydantic>=1.9.2,<3
 python-json-logger~=2.0.1
 PyYAML>=5.4.1
 s3fs==0.4.2
 simplejson~=3.17.2
 SQLAlchemy~=1.4.11
-tables>=3.10.1
+tables~=3.0


### PR DESCRIPTION
## Overview

Fixes issues with lib upgrades vs other dependencies. Specifically `libcst`.

## Impact

* Revert back to previous pinned versions of `pandas, pyarrow and tables`. 

## Checklist

The following won't apply in all cases - mark `N/A` next to point if not needed.

- [x] Appropriate unit tests added/updated
- [x] Module, function, class docstrings updated
- [x] Comments added to PR where necessary
- [x] Interface documentation updated
- [x] Semantic commits used for this PR, so that a CHANGELOG can be generated from them (don't delete your local branch! when tagging a new release from master)

## Release-Steps

- [ ] Merge PR
- [ ] Release new tag
